### PR TITLE
Make sure Dockerfile can be built and config its uses also up to date

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,3 +24,6 @@ runtime_call.json
 **/node_modules
 js/src/generated/
 integrations/rollup/data
+crates/stf/.artifacts
+test-data/**
+integrations/**

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -63,3 +63,41 @@ jobs:
         chmod +x scripts/rollup-starter.sh
         ./scripts/rollup-starter.sh
     secrets: inherit
+
+  docker-mock-da:
+    name: "Docker Mock DA"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Build Docker image
+        run: make build-docker-mock-da
+      
+      - name: Run Docker container in background
+        run: make run-docker-mock-da BACKGROUND=true
+      
+      - name: Wait for rollup to be ready
+        run: |
+          echo "Waiting for rollup to start..."
+          for i in {1..30}; do
+            if curl -f http://127.0.0.1:12346/healthcheck 2>/dev/null; then
+              echo "Rollup is ready!"
+              break
+            fi
+            echo "Waiting... ($i/30)"
+            sleep 2
+          done
+          
+          # Check if the container is still running
+          if ! docker ps | grep -q rollup-mock-da; then
+            echo "Container failed to start. Logs:"
+            docker logs rollup-mock-da
+            exit 1
+          fi
+      
+      - name: Stop Docker container
+        if: always()
+        run: make stop-docker-mock-da

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,8 +70,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+#      - name: Set up Docker Buildx
+#        uses: docker/setup-buildx-action@v3
       
       - name: Build Docker image
         run: make build-docker-mock-da

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,8 +70,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-#      - name: Set up Docker Buildx
-#        uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       
       - name: Build Docker image
         run: make build-docker-mock-da

--- a/Makefile
+++ b/Makefile
@@ -77,13 +77,19 @@ run-docker-mock-da: ## Start docker container with MockDa
 	@if [ "$(BACKGROUND)" = "true" ]; then \
 		docker run -d \
 			--name rollup-mock-da \
+			--cap-add SYS_NICE \
+			--cap-add IPC_LOCK \
+			--ulimit memlock=-1:-1 \
 			-v $(CURDIR)/test-data/docker/da:/mnt/da \
 			-v $(CURDIR)/test-data/docker/state:/mnt/state \
 			-v $(CURDIR)/configs/mock/rollup-dockerized.toml:/app/config/rollup.toml \
 			-p 12346:12346 \
 			rollup-starter:debug; \
 	else \
-		docker run \
+		docker run -it \
+			--cap-add SYS_NICE \
+			--cap-add IPC_LOCK \
+			--ulimit memlock=-1:-1 \
 			-v $(CURDIR)/test-data/docker/da:/mnt/da \
 			-v $(CURDIR)/test-data/docker/state:/mnt/state \
 			-v $(CURDIR)/configs/mock/rollup-dockerized.toml:/app/config/rollup.toml \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help check lint install-risc0-toolchain install-sp1-toolchain clean clean-db build-docker-mock-da run-docker-mock-da start-obs stop-obs start-celestia stop-celestia
+.PHONY: help check lint install-risc0-toolchain install-sp1-toolchain clean clean-db build-docker-mock-da run-docker-mock-da stop-docker-mock-da start-obs stop-obs start-celestia stop-celestia
 
 # Should remain at the top, otherwise `make` won't print help
 help: ## Display this help message
@@ -75,12 +75,26 @@ run-docker-mock-da: ## Start docker container with MockDa
 	mkdir -p test-data/docker
 	mkdir -p test-data/docker/da
 	mkdir -p test-data/docker/state
-	docker run --rm -it \
+	@if [ "$(BACKGROUND)" = "true" ]; then \
+		docker run --rm -d \
+			--name rollup-mock-da \
 			-v $(CURDIR)/test-data/docker/da:/mnt/da \
 			-v $(CURDIR)/test-data/docker/state:/mnt/state \
 			-v $(CURDIR)/configs/mock/rollup-dockerized.toml:/app/config/rollup.toml \
 			-p 12346:12346 \
-			rollup-starter:debug
+			rollup-starter:debug; \
+	else \
+		docker run --rm -it \
+			-v $(CURDIR)/test-data/docker/da:/mnt/da \
+			-v $(CURDIR)/test-data/docker/state:/mnt/state \
+			-v $(CURDIR)/configs/mock/rollup-dockerized.toml:/app/config/rollup.toml \
+			-p 12346:12346 \
+			rollup-starter:debug; \
+	fi
+
+stop-docker-mock-da: ## Stop docker container with MockDa
+	@docker stop rollup-mock-da 2>/dev/null || true
+	@docker rm rollup-mock-da 2>/dev/null || true
 
 start-obs:  ## Start observability stack
 	./scripts/start_observability.sh

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ run-docker-mock-da: ## Start docker container with MockDa
 	mkdir -p test-data/docker/da
 	mkdir -p test-data/docker/state
 	@if [ "$(BACKGROUND)" = "true" ]; then \
-		docker run --rm -d \
+		docker run -d \
 			--name rollup-mock-da \
 			-v $(CURDIR)/test-data/docker/da:/mnt/da \
 			-v $(CURDIR)/test-data/docker/state:/mnt/state \
@@ -83,7 +83,7 @@ run-docker-mock-da: ## Start docker container with MockDa
 			-p 12346:12346 \
 			rollup-starter:debug; \
 	else \
-		docker run --rm -it \
+		docker run \
 			-v $(CURDIR)/test-data/docker/da:/mnt/da \
 			-v $(CURDIR)/test-data/docker/state:/mnt/state \
 			-v $(CURDIR)/configs/mock/rollup-dockerized.toml:/app/config/rollup.toml \

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,6 @@ clean-db: ## Clean all databases
 build-docker-mock-da: ## Build docker container for the rollup with MockDa
 	DOCKER_BUILDKIT=1 \
 	docker build \
-	--ssh default \
 	-f ./integrations/rollup/Dockerfile.mock \
 	-t rollup-starter:debug \
 	.

--- a/Makefile
+++ b/Makefile
@@ -77,9 +77,7 @@ run-docker-mock-da: ## Start docker container with MockDa
 	@if [ "$(BACKGROUND)" = "true" ]; then \
 		docker run -d \
 			--name rollup-mock-da \
-			--cap-add SYS_NICE \
-			--cap-add IPC_LOCK \
-			--ulimit memlock=-1:-1 \
+			--privileged \
 			-v $(CURDIR)/test-data/docker/da:/mnt/da \
 			-v $(CURDIR)/test-data/docker/state:/mnt/state \
 			-v $(CURDIR)/configs/mock/rollup-dockerized.toml:/app/config/rollup.toml \
@@ -87,9 +85,7 @@ run-docker-mock-da: ## Start docker container with MockDa
 			rollup-starter:debug; \
 	else \
 		docker run -it \
-			--cap-add SYS_NICE \
-			--cap-add IPC_LOCK \
-			--ulimit memlock=-1:-1 \
+			--privileged \
 			-v $(CURDIR)/test-data/docker/da:/mnt/da \
 			-v $(CURDIR)/test-data/docker/state:/mnt/state \
 			-v $(CURDIR)/configs/mock/rollup-dockerized.toml:/app/config/rollup.toml \

--- a/integrations/rollup/Dockerfile.mock
+++ b/integrations/rollup/Dockerfile.mock
@@ -1,4 +1,4 @@
-FROM rust:1.81 AS builder
+FROM rust:1.88 AS builder
 
 # Single switch for debug / release (defaults to debug)
 # accepted values: debug | release
@@ -27,7 +27,7 @@ RUN --mount=type=ssh \
     fi
 
 # --- runtime stage -------------------------------------------------
-FROM rust:1.81-slim AS runtime
+FROM rust:1.88-slim AS runtime
 
 # Re-declare the same ARG so it’s visible in this stage as well
 ARG BUILD_MODE=debug


### PR DESCRIPTION
This PR adds CI check for 2 things:

* Docker file for building a rollup is correct
* Config `configs/mock/rollup_dockerized.toml` has been upgraded.

This prevents 

Note: running rollup in docker on MacOS is not supported, due to NOMT will try to use io_uring because it will thing it is a linux, but MacOS blocks that. I will add check and message to make command in follow up PR