### PR TITLE
Update and unify rollup configs

### DIFF
--- a/configs/celestia/rollup.toml
+++ b/configs/celestia/rollup.toml
@@ -12,14 +12,11 @@ signer_private_key = "aec34bb1cfae6e906594dc106af4057a9046f769e2eeed67d040f0107e
 [storage]
 # The path to the rollup's data directory. Paths that do not begin with `/` are interpreted as relative paths.
 path = "./rollup-state/rollup-starter-data-celestia"
-
 user_commit_concurrency = 6
 kernel_commit_concurrency = 2
 # Disable pruning for now
 # pruner_block_interval = 100_000
 pruner_versions_to_keep = 100
-#state_cache_size = 10000000000 # 10GB
-state_cache_size = 4294967296
 # The number of 4kb buckets to allocate for the state DB
 # The state DB will not exceed this size, and you'll get a warning when it fills up to 90% capacity.
 # user_hashtable_buckets = 64_000_000 # 256 GB. You will need much more for production deployments
@@ -61,7 +58,8 @@ max_number_of_transitions_in_memory = 20
 
 
 [sequencer]
-max_batch_size_bytes = 2048576
+# 7 MiB
+max_batch_size_bytes = 7340032
 max_concurrent_blobs = 128
 max_allowed_node_distance_behind = 10
 rollup_address = "0xA6edfca3AA985Dd3CC728BFFB700933a986aC085"

--- a/configs/mock/rollup-dockerized.toml
+++ b/configs/mock/rollup-dockerized.toml
@@ -40,7 +40,8 @@ max_number_of_transitions_in_memory = 20
 
 
 [sequencer]
-max_batch_size_bytes = 1048576
+# 7 MiB
+max_batch_size_bytes = 7340032
 max_concurrent_blobs = 128
 max_allowed_node_distance_behind = 10
 rollup_address = "0xA6edfca3AA985Dd3CC728BFFB700933a986aC085"

--- a/configs/mock/rollup.toml
+++ b/configs/mock/rollup.toml
@@ -21,19 +21,16 @@ kernel_commit_concurrency = 2
 # Disable pruning for now
 # pruner_block_interval = 100_000
 pruner_versions_to_keep = 100
-
-#state_cache_size = 10000000000 # 10GB
-#state_cache_size = 4294967296
 # The number of 4kb buckets to allocate for the state DB
 # The state DB will not exceed this size, and you'll get a warning when it fills up to 90% capacity.
 #user_hashtable_buckets = 64_000_000 # 256 GB. You will need much more for production deployments
-# This paramater introduces performance penalty and should be changed in production.
 user_hashtable_buckets = 1_000_000
+# This paramater introduces performance penalty and should be changed in production.
 # It allows avoiding allocating 256GB at the start
 user_preallocate_ht = false 
 
 [runner]
-da_polling_interval_ms = 200
+da_polling_interval_ms = 2_000
 
 [runner.http_config]
 bind_host = "0.0.0.0"
@@ -63,7 +60,8 @@ max_number_of_transitions_in_memory = 20
 
 
 [sequencer]
-max_batch_size_bytes = 8388608 # 8 MiB
+# 7 MiB
+max_batch_size_bytes = 7340032
 max_concurrent_blobs = 128
 max_allowed_node_distance_behind = 10
 rollup_address = "0xA6edfca3AA985Dd3CC728BFFB700933a986aC085"

--- a/configs/mock_external/rollup.toml
+++ b/configs/mock_external/rollup.toml
@@ -52,7 +52,8 @@ max_number_of_transitions_in_memory = 20
 
 
 [sequencer]
-max_batch_size_bytes = 8388608 # 8 MiB
+# 7 MiB
+max_batch_size_bytes = 7340032
 max_concurrent_blobs = 128
 max_allowed_node_distance_behind = 10
 rollup_address = "0xA6edfca3AA985Dd3CC728BFFB700933a986aC085"


### PR DESCRIPTION

* Max blob size is set to 7MiB, which has been confirmed on celestia. Should be the same between MockDa and Celestia to avoid surprises when migrating
* da_polling interval is set to be the same to match experience of celestia on mock da
* storage configuration unified