### PR TITLE
Adding explicit DA deps with arbitrary for soak script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8890,6 +8890,8 @@ dependencies = [
  "reqwest",
  "rollup-starter",
  "sov-api-spec",
+ "sov-celestia-adapter",
+ "sov-mock-da",
  "sov-modules-rollup-blueprint",
  "sov-risc0-adapter",
  "sov-rollup-interface",
@@ -10189,6 +10191,7 @@ version = "0.3.0"
 source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=51c8e7bbbf1a935a967ec85839da4a17b2ddaad5#51c8e7bbbf1a935a967ec85839da4a17b2ddaad5"
 dependencies = [
  "anyhow",
+ "arbitrary",
  "async-trait",
  "backon",
  "bech32",
@@ -10199,6 +10202,7 @@ dependencies = [
  "futures",
  "hex",
  "nmt-rs",
+ "proptest",
  "prost 0.13.5",
  "rand 0.8.5",
  "schemars 0.8.22",

--- a/scripts/soak-test/Cargo.toml
+++ b/scripts/soak-test/Cargo.toml
@@ -13,23 +13,26 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 futures = { version = "0.3", default-features = false }
 reqwest = { version = "0.12", features = ["rustls-tls"] }
- 
+
 
 sov-soak-testing-lib = { workspace = true }
 sov-api-spec = { workspace = true }
 sov-rollup-interface = { workspace = true, features = ["arbitrary"] }
 sov-modules-rollup-blueprint = { workspace = true, features = ["native"] }
 sov-test-utils = { workspace = true, features = ["arbitrary"] }
-sov-risc0-adapter = { workspace = true, optional = true, features = ["arbitrary", "native"] } 
+sov-risc0-adapter = { workspace = true, optional = true, features = ["arbitrary", "native"] }
 sov-sp1-adapter = { workspace = true, optional = true, features = ["arbitrary", "native"] }
 
-rollup-starter = { path = "../../crates/rollup/", default-features = false }
+rollup-starter = { path = "../../crates/rollup", default-features = false }
+
+sov-celestia-adapter = { workspace = true, optional = true, features = ["native", "arbitrary"] }
+sov-mock-da = { workspace = true, optional = true, features = ["native", "arbitrary"] }
 
 [features]
 default = ["mock_da", "mock_zkvm"]
-mock_da = ["rollup-starter/mock_da"]
-mock_da_external = ["rollup-starter/mock_da_external"]
-celestia_da = ["rollup-starter/celestia_da"]
+mock_da = ["rollup-starter/mock_da", "dep:sov-mock-da"]
+mock_da_external = ["rollup-starter/mock_da_external", "dep:sov-mock-da"]
+celestia_da = ["rollup-starter/celestia_da", "dep:sov-celestia-adapter"]
 sp1 = ["sov-sp1-adapter", "rollup-starter/sp1"]
 risc0 = ["sov-risc0-adapter", "rollup-starter/risc0"]
 mock_zkvm = ["rollup-starter/mock_zkvm"]


### PR DESCRIPTION
Fixes this error:

```
argo build --bin --bin rollup-starter-soak-test -p rollup-starter-soak-test --no-default-features --features=celestia_da,mock_zkvm


error[E0277]: the trait bound `for<'a> CelestiaAddress: arbitrary::Arbitrary<'a>` is not satisfied
   --> /Users/nikolai/.cargo/git/checkouts/sovereign-sdk-de4a3e6cb918f1e3/ac4d341/crates/adapters/celestia/src/types/mod.rs:114:20
    |
114 |     type Address = CelestiaAddress;
    |                    ^^^^^^^^^^^^^^^ the trait `for<'a> arbitrary::Arbitrary<'a>` is not implemented for `CelestiaAddress`
    |
    = help: the following other types implement trait `arbitrary::Arbitrary<'a>`:
              `&'a [u8]` implements `arbitrary::Arbitrary<'a>`
              `&'a str` implements `arbitrary::Arbitrary<'a>`
              `()` implements `arbitrary::Arbitrary<'a>`
              `(B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, A)` implements `arbitrary::Arbitrary<'a>`
              `(C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, B)` implements `arbitrary::Arbitrary<'a>`
              `(D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, C)` implements `arbitrary::Arbitrary<'a>`
              `(E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, D)` implements `arbitrary::Arbitrary<'a>`
              `(F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, E)` implements `arbitrary::Arbitrary<'a>`
            and 135 others
    = note: required for `<BlobWithSender as BlobReaderTrait>::Address` to implement `MaybeArbitrary`
    = note: required for `<BlobWithSender as BlobReaderTrait>::Address` to implement `BasicAddress`
note: required by a bound in `sov_rollup_interface::da::BlobReaderTrait::Address`
   --> /Users/nikolai/.cargo/git/checkouts/sovereign-sdk-de4a3e6cb918f1e3/ac4d341/crates/rollup-interface/src/state_machine/da.rs:151:19
    |
151 |     type Address: BasicAddress;
    |                   ^^^^^^^^^^^^ required by this bound in `BlobReaderTrait::Address`

error[E0277]: the trait bound `for<'a> CelestiaAddress: arbitrary::Arbitrary<'a>` is not satisfied
  --> /Users/nikolai/.cargo/git/checkouts/sovereign-sdk-de4a3e6cb918f1e3/ac4d341/crates/adapters/celestia/src/verifier/mod.rs:59:20
   |
59 |     type Address = CelestiaAddress;
   |                    ^^^^^^^^^^^^^^^ the trait `for<'a> arbitrary::Arbitrary<'a>` is not implemented for `CelestiaAddress`
   |
   = help: the following other types implement trait `arbitrary::Arbitrary<'a>`:
             `&'a [u8]` implements `arbitrary::Arbitrary<'a>`
             `&'a str` implements `arbitrary::Arbitrary<'a>`
             `()` implements `arbitrary::Arbitrary<'a>`
             `(B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, A)` implements `arbitrary::Arbitrary<'a>`
             `(C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, B)` implements `arbitrary::Arbitrary<'a>`
             `(D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, C)` implements `arbitrary::Arbitrary<'a>`
             `(E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, D)` implements `arbitrary::Arbitrary<'a>`
             `(F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, E)` implements `arbitrary::Arbitrary<'a>`
           and 135 others
   = note: required for `<CelestiaSpec as DaSpec>::Address` to implement `MaybeArbitrary`
   = note: required for `<CelestiaSpec as DaSpec>::Address` to implement `BasicAddress`
note: required by a bound in `sov_rollup_interface::da::DaSpec::Address`
  --> /Users/nikolai/.cargo/git/checkouts/sovereign-sdk-de4a3e6cb918f1e3/ac4d341/crates/rollup-interface/src/state_machine/da.rs:34:19
   |
34 |     type Address: BasicAddress + Send + Sync;
   |                   ^^^^^^^^^^^^ required by this bound in `DaSpec::Address`

error[E0277]: the trait bound `for<'a> CelestiaAddress: arbitrary::Arbitrary<'a>` is not satisfied
   --> /Users/nikolai/.cargo/git/checkouts/sovereign-sdk-de4a3e6cb918f1e3/ac4d341/crates/adapters/celestia/src/verifier/address.rs:144:45
    |
144 | impl sov_rollup_interface::BasicAddress for CelestiaAddress {}
    |                                             ^^^^^^^^^^^^^^^ the trait `for<'a> arbitrary::Arbitrary<'a>` is not implemented for `CelestiaAddress`
    |
    = help: the following other types implement trait `arbitrary::Arbitrary<'a>`:
              `&'a [u8]` implements `arbitrary::Arbitrary<'a>`
              `&'a str` implements `arbitrary::Arbitrary<'a>`
              `()` implements `arbitrary::Arbitrary<'a>`
              `(B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, A)` implements `arbitrary::Arbitrary<'a>`
              `(C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, B)` implements `arbitrary::Arbitrary<'a>`
              `(D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, C)` implements `arbitrary::Arbitrary<'a>`
              `(E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, D)` implements `arbitrary::Arbitrary<'a>`
              `(F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, E)` implements `arbitrary::Arbitrary<'a>`
            and 135 others
    = note: required for `CelestiaAddress` to implement `MaybeArbitrary`
note: required by a bound in `BasicAddress`
   --> /Users/nikolai/.cargo/git/checkouts/sovereign-sdk-de4a3e6cb918f1e3/ac4d341/crates/rollup-interface/src/state_machine/mod.rs:126:7
    |
107 | pub trait BasicAddress:
    |           ------------ required by a bound in this trait
...
126 |     + MaybeArbitrary
    |       ^^^^^^^^^^^^^^ required by this bound in `BasicAddress`

For more information about this error, try `rustc --explain E0277`.
error: could not compile `sov-celestia-adapter` (lib) due to 3 previous errors
warning: build failed, waiting for other jobs to finish...
```