### PR TITLE
Acceptance test reduce number of buckets

### DIFF
--- a/scripts/acceptance-test/rollup_config.toml
+++ b/scripts/acceptance-test/rollup_config.toml
@@ -22,8 +22,8 @@ block_time_ms = 3_000
 path = "{rollup_data_path}"
 user_commit_concurrency = 6
 kernel_commit_concurrency = 2
-# Pruner is disabled
-# pruner_block_interval = 1000_000
+# Run pruning once every 1000 blocks. Prune any keys more than 100 versions old
+pruner_block_interval = 1000_000
 pruner_versions_to_keep = 100
 state_cache_size = 10000000000 # 10GB
 # The number of 4kb buckets to allocate for the state DB
@@ -31,7 +31,7 @@ state_cache_size = 10000000000 # 10GB
 user_hashtable_buckets = 2_000_000 # 8 GB. You will need much more for production deployments
 
 [runner]
-da_polling_interval_ms = 1_000
+da_polling_interval_ms = 200
 
 [runner.http_config]
 bind_host = "0.0.0.0"


### PR DESCRIPTION
Currently each acceptance test data folder takes a little more than 256G, which is mostly NOMT.

And based on the data, we consume less than 1% of the buckets:

<img width="1505" height="753" alt="Screenshot 2026-01-16 at 09 25 44" src="https://github.com/user-attachments/assets/0b5a82bb-1b8c-4a4e-a8c9-5418418a4a51" />

Reducing the size of buckets opens opportunity to generate data for several commits at the same time, speeding up promotion process.

It also disabled pruner and fixes tabs in the genesis