### PR TITLE
white-space only change in scripts/acceptance-test/genesis.json

### DIFF
--- a/scripts/acceptance-test/genesis.json
+++ b/scripts/acceptance-test/genesis.json
@@ -1,135 +1,135 @@
 {
-	"accounts": {
-      "accounts": [],
-      "enable_custom_account_mappings": false
-	},
-	"operator_incentives": {
-	  "reward_address": "0xA6edfca3AA985Dd3CC728BFFB700933a986aC085"
-	},
-	"attester_incentives": {
-	  "minimum_attester_bond": [1000, 1000],
-	  "minimum_challenger_bond": [1000, 1000],
-	  "initial_attesters": [
-		["0xA6edfca3AA985Dd3CC728BFFB700933a986aC085", "200000"]
-	  ],
-	  "rollup_finality_period": 5,
-	  "maximum_attested_height": 0,
-	  "light_client_finalized_height": 0
-	},
-	"bank": {
-	  "gas_token_config": {
-		"token_name": "sov-token",
-		"address_and_balances": [
-		  [
-			"0xA6edfca3AA985Dd3CC728BFFB700933a986aC085",
-			"10000000000000000"
-		  ],
-		  [
-			"0x23B6445f524daDee9fb576627740AaD23Afbe8b7",
-			"1000000000"
-		  ],
-		  [
-			"0x9b08ce57a93751aE790698A2C9ebc76A78F23E25",
-			"1000000000"
-		  ],
-		  [
-			"0xB14D211d69aff5190451b336bDe0975b57555D36",
-			"1000000000"
-		  ],
-		  [
-			"0xe78B5e6d2BfF36b462cc29772526Dd4EBF42E98b",
-			"1000000000"
-		  ],
-		  [
-			"0x0E0BcFa6A9D9C5694B754Aa3BF86360EE23eb52B",
-			"1000000000"
-		  ],
-          [
-            "0xc13b65f7c53Cd6db2EA205a4b574b4a0858720A6",
-            "10000000000000000000000000000"
-          ],
-          [
-            "0xBaEb92889696217A3A6be2175E5a95dC4cFFC9f7",
-            "10000000000000000000000000000"
-          ],
-          [
-            "0x2b9A8bdd2fe54C75116986f2fa892210A5f22915",
-            "10000000000000000000000000000"
-          ],
-		  [
-			"0x267d5F5Ba12AcD07Ce5D0831B17aB5927fEBCd48",
-			"1000000000"
-		  ]
-		],
-		"admins": ["0xA6edfca3AA985Dd3CC728BFFB700933a986aC085"]
-	  },
-	  "tokens": []
-	},
-	"chain_state": {
-	  "current_time": 0,
-	  "operating_mode": "operator",
-	  "inner_code_commitment": [0, 0, 0, 0, 0, 0, 0, 0],
-	  "outer_code_commitment": [0, 0, 0, 0, 0, 0, 0, 0],
-	  "genesis_da_height": 0
-	},
-	"paymaster": {
-	  "payers": [
-		{
-		  "payer_address": "0xA6edfca3AA985Dd3CC728BFFB700933a986aC085",
-		  "policy": {
-			"default_payee_policy": {
-			  "allow": {}
-			},
-			"payees": [],
-			"authorized_updaters": [],
-			"authorized_sequencers": "all"
-		  },
-		  "sequencers_to_register": [
-			"0000000000000000000000000000000000000000000000000000000000000000"
-		  ]
-		}
-	  ]
-	},
-	"prover_incentives": {
-	  "proving_penalty": [10, 10],
-	  "minimum_bond": [1000, 1000],
-	  "initial_provers": [
-		["0xA6edfca3AA985Dd3CC728BFFB700933a986aC085", "200000"]
-	  ]
-	},
-	"sequencer_registry": {
-	  "minimum_bond": "5000",
-	  "sequencer_config": {
-		"seq_rollup_address": "0xA6edfca3AA985Dd3CC728BFFB700933a986aC085",
-		"seq_da_address": "0000000000000000000000000000000000000000000000000000000000000000",
-		"seq_bond": "100000000000",
-		"is_preferred_sequencer": true
-	  }
-	},
-	"uniqueness": null,
-	"blob_storage": null,
-	"revenue_share": null,
-	"mailbox": null,
-	"interchain_gas_paymaster": null,
-	"merkle_tree_hook": null,
-	"warp": null,
-    "state_consistency": null,
-    "value_setter": null,
-    "evm": {
-      "accounts": [],
-      "contract_creation_policy": "everyone",
-      "initial_base_fee": 7,
-      "genesis_timestamp": 0,
-	  "admin": "0xA6edfca3AA985Dd3CC728BFFB700933a986aC085",
-      "chain_spec": {
-        "limit_contract_code_size": 524288,
-        "coinbase": "0x0000000000000000000000000000000000000000",
-        "block_gas_limit": 30000000,
-        "base_fee_params": {
-          "max_change_denominator": 8,
-          "elasticity_multiplier": 2
+  "accounts": {
+    "accounts": [],
+    "enable_custom_account_mappings": false
+  },
+  "operator_incentives": {
+    "reward_address": "0xA6edfca3AA985Dd3CC728BFFB700933a986aC085"
+  },
+  "attester_incentives": {
+    "minimum_attester_bond": [1000, 1000],
+    "minimum_challenger_bond": [1000, 1000],
+    "initial_attesters": [
+      ["0xA6edfca3AA985Dd3CC728BFFB700933a986aC085", "200000"]
+    ],
+    "rollup_finality_period": 5,
+    "maximum_attested_height": 0,
+    "light_client_finalized_height": 0
+  },
+  "bank": {
+    "gas_token_config": {
+      "token_name": "sov-token",
+      "address_and_balances": [
+        [
+          "0xA6edfca3AA985Dd3CC728BFFB700933a986aC085",
+          "10000000000000000"
+        ],
+        [
+          "0x23B6445f524daDee9fb576627740AaD23Afbe8b7",
+          "1000000000"
+        ],
+        [
+          "0x9b08ce57a93751aE790698A2C9ebc76A78F23E25",
+          "1000000000"
+        ],
+        [
+          "0xB14D211d69aff5190451b336bDe0975b57555D36",
+          "1000000000"
+        ],
+        [
+          "0xe78B5e6d2BfF36b462cc29772526Dd4EBF42E98b",
+          "1000000000"
+        ],
+        [
+          "0x0E0BcFa6A9D9C5694B754Aa3BF86360EE23eb52B",
+          "1000000000"
+        ],
+        [
+          "0xc13b65f7c53Cd6db2EA205a4b574b4a0858720A6",
+          "10000000000000000000000000000"
+        ],
+        [
+          "0xBaEb92889696217A3A6be2175E5a95dC4cFFC9f7",
+          "10000000000000000000000000000"
+        ],
+        [
+          "0x2b9A8bdd2fe54C75116986f2fa892210A5f22915",
+          "10000000000000000000000000000"
+        ],
+        [
+          "0x267d5F5Ba12AcD07Ce5D0831B17aB5927fEBCd48",
+          "1000000000"
+        ]
+      ],
+      "admins": ["0xA6edfca3AA985Dd3CC728BFFB700933a986aC085"]
+    },
+    "tokens": []
+  },
+  "chain_state": {
+    "current_time": 0,
+    "operating_mode": "operator",
+    "inner_code_commitment": [0, 0, 0, 0, 0, 0, 0, 0],
+    "outer_code_commitment": [0, 0, 0, 0, 0, 0, 0, 0],
+    "genesis_da_height": 0
+  },
+  "paymaster": {
+    "payers": [
+      {
+        "payer_address": "0xA6edfca3AA985Dd3CC728BFFB700933a986aC085",
+        "policy": {
+          "default_payee_policy": {
+            "allow": {}
+          },
+          "payees": [],
+          "authorized_updaters": [],
+          "authorized_sequencers": "all"
         },
-        "hardforks": [[0, "CANCUN"]]
+        "sequencers_to_register": [
+          "0000000000000000000000000000000000000000000000000000000000000000"
+        ]
       }
+    ]
+  },
+  "prover_incentives": {
+    "proving_penalty": [10, 10],
+    "minimum_bond": [1000, 1000],
+    "initial_provers": [
+      ["0xA6edfca3AA985Dd3CC728BFFB700933a986aC085", "200000"]
+    ]
+  },
+  "sequencer_registry": {
+    "minimum_bond": "5000",
+    "sequencer_config": {
+      "seq_rollup_address": "0xA6edfca3AA985Dd3CC728BFFB700933a986aC085",
+      "seq_da_address": "0000000000000000000000000000000000000000000000000000000000000000",
+      "seq_bond": "100000000000",
+      "is_preferred_sequencer": true
     }
+  },
+  "uniqueness": null,
+  "blob_storage": null,
+  "revenue_share": null,
+  "mailbox": null,
+  "interchain_gas_paymaster": null,
+  "merkle_tree_hook": null,
+  "warp": null,
+  "state_consistency": null,
+  "value_setter": null,
+  "evm": {
+    "accounts": [],
+    "contract_creation_policy": "everyone",
+    "initial_base_fee": 7,
+    "genesis_timestamp": 0,
+    "admin": "0xA6edfca3AA985Dd3CC728BFFB700933a986aC085",
+    "chain_spec": {
+      "limit_contract_code_size": 524288,
+      "coinbase": "0x0000000000000000000000000000000000000000",
+      "block_gas_limit": 30000000,
+      "base_fee_params": {
+        "max_change_denominator": 8,
+        "elasticity_multiplier": 2
+      },
+      "hardforks": [[0, "CANCUN"]]
+    }
+  }
 }


### PR DESCRIPTION
For easier comparison.

So GitHub is not that great about whitespace only diff, so here is some screenshot.

<img width="1174" height="748" alt="Screenshot 2026-01-16 at 12 43 03" src="https://github.com/user-attachments/assets/6763280a-74c3-4bec-8c85-5f83707ea0b2" />

You can trust me or checkout into your favourite IDE and check.


Current diff:

```
[12:44:41] rollup-starter on  nikolai/clean-up-genesises ▸ diff configs/mock/genesis.json scripts/acceptance-test/genesis.json
25c25
<           "1000000000000000000000000000000000"
---
>           "10000000000000000"
28,31d27
<           "0xe7d2b7610d1574610cbd903ea896c59d17470633",
<           "1000000000000000000000000000000000"
<         ],
<         [
59c55
< 	      [
---
>         [
64,71d59
<           "0xca7f2cF9b6d765334A4A9D5744e57563EA76C602",
<           "10000000000000000000000000000"
<         ],
<         [
<           "0x74bb92E136628E7028e2290fF60A8EC83Eea904f",
<           "10000000000000000000000000000"
<         ],
<         [
117c105
<       "seq_bond": "100000000000000000000000000000000",
---
>       "seq_bond": "100000000000",
127a116
>   "state_consistency": null,
138c127
<       "block_gas_limit": 1000000000,
---
>       "block_gas_limit": 30000000,
```
