### PR TITLE
Update to the latest dev 2026-04-08

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1858,7 +1858,6 @@ checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core 0.4.5",
- "base64 0.22.1",
  "bytes",
  "futures-util",
  "http 1.4.0",
@@ -1877,10 +1876,8 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite 0.24.0",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
@@ -1894,11 +1891,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core 0.5.6",
+ "base64 0.22.1",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
  "itoa",
  "matchit 0.8.4",
  "memchr",
@@ -1906,10 +1907,17 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite 0.28.0",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1949,16 +1957,18 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "axum-server"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
+checksum = "b1df331683d982a0b9492b38127151e6453639cd34926eb9c07d4cd8c6d22bfc"
 dependencies = [
  "arc-swap",
  "bytes",
+ "either",
  "fs-err",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -1966,7 +1976,6 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls 0.23.37",
- "rustls-pemfile",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -2077,12 +2086,11 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bcs"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b6598a2f5d564fb7855dc6b06fd1c38cff5a72bd8b863a4d021938497b440a"
+checksum = "302fd2afb39688efc82f6138a68861b8f04f95be5faab2a06805a8a49f28deb6"
 dependencies = [
- "serde",
- "thiserror 1.0.69",
+ "serde_core",
 ]
 
 [[package]]
@@ -4309,6 +4317,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -6484,27 +6493,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
-name = "modular-bitfield"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53d79ba8304ac1c4f9eb3b9d281f21f7be9d4626f72ce7df4ad8fbde4f38a74"
-dependencies = [
- "modular-bitfield-impl",
- "static_assertions",
-]
-
-[[package]]
-name = "modular-bitfield-impl"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "mti"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6587,7 +6575,7 @@ dependencies = [
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 
 [[package]]
 name = "nix"
@@ -6982,23 +6970,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "op-alloy-consensus"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726da827358a547be9f1e37c2a756b9e3729cb0350f43408164794b370cad8ae"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "derive_more 2.1.1",
- "serde",
- "serde_with",
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "opaque-debug"
@@ -7865,30 +7836,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8688,131 +8635,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-codecs"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-trie",
- "bytes",
- "modular-bitfield",
- "op-alloy-consensus",
- "reth-codecs-derive",
- "reth-zstd-compressors",
- "serde",
-]
-
-[[package]]
-name = "reth-codecs-derive"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "reth-consensus"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-primitives",
- "auto_impl",
- "reth-execution-types",
- "reth-primitives-traits",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "reth-errors"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "reth-consensus",
- "reth-execution-errors",
- "reth-storage-errors",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "reth-ethereum-forks"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-eip2124",
- "alloy-hardforks",
- "alloy-primitives",
- "auto_impl",
- "once_cell",
- "rustc-hash 2.1.1",
-]
-
-[[package]]
-name = "reth-ethereum-primitives"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "reth-codecs",
- "reth-primitives-traits",
- "reth-zstd-compressors",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "reth-execution-errors"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-evm",
- "alloy-primitives",
- "alloy-rlp",
- "nybbles",
- "reth-storage-errors",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "reth-execution-types"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-evm",
- "alloy-primitives",
- "derive_more 2.1.1",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
- "reth-trie-common",
- "revm",
-]
-
-[[package]]
-name = "reth-primitives"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "once_cell",
- "reth-ethereum-forks",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
- "reth-static-file-types",
-]
-
-[[package]]
 name = "reth-primitives-traits"
 version = "1.9.0"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
@@ -8822,83 +8644,15 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-eth",
  "alloy-trie",
  "auto_impl",
  "bytes",
  "derive_more 2.1.1",
  "once_cell",
- "op-alloy-consensus",
- "reth-codecs",
  "revm-bytecode",
  "revm-primitives",
  "revm-state",
- "secp256k1 0.30.0",
- "serde",
- "serde_with",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "reth-prune-types"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-primitives",
- "derive_more 2.1.1",
- "strum 0.27.2",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "reth-static-file-types"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-primitives",
- "derive_more 2.1.1",
- "serde",
- "strum 0.27.2",
-]
-
-[[package]]
-name = "reth-storage-errors"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "derive_more 2.1.1",
- "reth-primitives-traits",
- "reth-prune-types",
- "reth-static-file-types",
- "revm-database-interface",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "reth-trie-common"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-trie",
- "derive_more 2.1.1",
- "itertools 0.14.0",
- "nybbles",
- "reth-primitives-traits",
- "revm-database",
-]
-
-[[package]]
-name = "reth-zstd-compressors"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "zstd",
 ]
 
 [[package]]
@@ -9261,7 +9015,7 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "tracing",
- "zip",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -9538,7 +9292,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum 0.7.9",
+ "axum 0.8.8",
  "borsh",
  "bytes",
  "clap",
@@ -11146,7 +10900,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11161,7 +10915,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -11182,7 +10936,7 @@ dependencies = [
 [[package]]
 name = "sov-api-spec"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "backon",
@@ -11199,14 +10953,14 @@ dependencies = [
  "sov-modules-api",
  "sov-rollup-interface",
  "tokio",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite 0.29.0",
  "tracing",
 ]
 
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11227,7 +10981,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11248,7 +11002,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-sender"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11271,7 +11025,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11291,7 +11045,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11303,7 +11057,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -11323,7 +11077,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11357,7 +11111,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11373,7 +11127,7 @@ dependencies = [
 [[package]]
 name = "sov-cli"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11396,7 +11150,7 @@ dependencies = [
 [[package]]
 name = "sov-db"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11432,7 +11186,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -11450,7 +11204,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11468,7 +11222,7 @@ dependencies = [
 [[package]]
 name = "sov-eth-client"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -11496,12 +11250,10 @@ dependencies = [
 [[package]]
 name = "sov-eth-dev-signer"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "alloy-consensus",
- "alloy-rpc-types",
- "reth-primitives",
- "revm",
+ "alloy-primitives",
  "secp256k1 0.30.0",
  "thiserror 2.0.18",
 ]
@@ -11509,7 +11261,7 @@ dependencies = [
 [[package]]
 name = "sov-ethereum"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11540,7 +11292,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11557,9 +11309,6 @@ dependencies = [
  "itertools 0.14.0",
  "jsonrpsee",
  "rand 0.8.5",
- "reth-ethereum-primitives",
- "reth-primitives",
- "reth-primitives-traits",
  "revm",
  "revm-database-interface",
  "revm-inspectors",
@@ -11585,7 +11334,7 @@ dependencies = [
 [[package]]
 name = "sov-evm-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -11601,7 +11350,7 @@ dependencies = [
 [[package]]
 name = "sov-full-node-configs"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "schemars 0.8.22",
@@ -11615,7 +11364,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11639,7 +11388,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -11653,10 +11402,10 @@ dependencies = [
 [[package]]
 name = "sov-ledger-apis"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
- "axum 0.7.9",
+ "axum 0.8.8",
  "borsh",
  "derive_more 2.1.1",
  "futures",
@@ -11678,7 +11427,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -11701,12 +11450,12 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "arbitrary",
  "async-trait",
- "axum 0.7.9",
+ "axum 0.8.8",
  "borsh",
  "bytes",
  "chrono",
@@ -11734,7 +11483,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11754,12 +11503,12 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "arbitrary",
  "async-trait",
- "axum 0.7.9",
+ "axum 0.8.8",
  "bech32",
  "borsh",
  "bs58",
@@ -11794,14 +11543,14 @@ dependencies = [
  "tracing",
  "tracing-test",
  "unwrap-infallible",
- "utoipa 4.2.3",
+ "utoipa",
  "utoipa-swagger-ui",
 ]
 
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bech32",
@@ -11823,7 +11572,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-rollup-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11862,10 +11611,10 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
- "axum 0.7.9",
+ "axum 0.8.8",
  "borsh",
  "hex",
  "jsonrpsee",
@@ -11883,7 +11632,7 @@ dependencies = [
 [[package]]
 name = "sov-node-client"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11902,7 +11651,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11920,7 +11669,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11942,7 +11691,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11961,7 +11710,7 @@ dependencies = [
 [[package]]
 name = "sov-proxy-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11978,10 +11727,10 @@ dependencies = [
 [[package]]
 name = "sov-rest-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
- "axum 0.7.9",
+ "axum 0.8.8",
  "client-ip",
  "derive_more 2.1.1",
  "flate2",
@@ -12002,7 +11751,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12017,7 +11766,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -12046,9 +11795,9 @@ dependencies = [
 [[package]]
 name = "sov-rollup-apis"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
- "axum 0.7.9",
+ "axum 0.8.8",
  "base64 0.22.1",
  "borsh",
  "derivative",
@@ -12073,7 +11822,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -12119,7 +11868,7 @@ dependencies = [
 [[package]]
 name = "sov-rpc-eth-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12131,7 +11880,6 @@ dependencies = [
  "derive-new",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "reth-errors",
  "reth-primitives-traits",
  "revm",
  "serde",
@@ -12142,11 +11890,11 @@ dependencies = [
 [[package]]
 name = "sov-sequencer"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum 0.7.9",
+ "axum 0.8.8",
  "backon",
  "base64 0.22.1",
  "bincode",
@@ -12192,7 +11940,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -12225,7 +11973,7 @@ dependencies = [
 [[package]]
 name = "sov-soak-testing-lib"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12247,7 +11995,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -12271,7 +12019,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -12299,11 +12047,11 @@ dependencies = [
 [[package]]
 name = "sov-stf-runner"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum 0.7.9",
+ "axum 0.8.8",
  "backon",
  "bincode",
  "borsh",
@@ -12333,7 +12081,7 @@ dependencies = [
 [[package]]
 name = "sov-synthetic-load"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12351,7 +12099,7 @@ dependencies = [
 [[package]]
 name = "sov-test-modules"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12370,7 +12118,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12385,7 +12133,7 @@ dependencies = [
 [[package]]
 name = "sov-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12445,9 +12193,10 @@ dependencies = [
 [[package]]
 name = "sov-transaction-generator"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
+ "async-trait",
  "backon",
  "borsh",
  "derivative",
@@ -12478,7 +12227,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12491,7 +12240,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -12513,7 +12262,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "bech32",
  "borsh",
@@ -12530,7 +12279,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -12540,7 +12289,7 @@ dependencies = [
 [[package]]
 name = "sov-value-setter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12566,7 +12315,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -14063,18 +13812,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.24.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
@@ -14087,6 +13824,18 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tungstenite 0.28.0",
  "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -14590,24 +14339,6 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 1.4.0",
- "httparse",
- "log",
- "rand 0.8.5",
- "sha1",
- "thiserror 1.0.69",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
@@ -14623,6 +14354,22 @@ dependencies = [
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -14956,18 +14703,6 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"
-version = "4.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
-dependencies = [
- "indexmap 2.13.0",
- "serde",
- "serde_json",
- "utoipa-gen 4.3.1",
-]
-
-[[package]]
-name = "utoipa"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
@@ -14975,19 +14710,7 @@ dependencies = [
  "indexmap 2.13.0",
  "serde",
  "serde_json",
- "utoipa-gen 5.4.0",
-]
-
-[[package]]
-name = "utoipa-gen"
-version = "4.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c24e8ab68ff9ee746aad22d39b5535601e6416d1b0feeabf78be986a5c4392"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "utoipa-gen",
 ]
 
 [[package]]
@@ -15003,20 +14726,21 @@ dependencies = [
 
 [[package]]
 name = "utoipa-swagger-ui"
-version = "7.1.1-rc.0"
+version = "9.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd1174c37d2bdc9a2ce8d94aa0baf3e3c4862f80b7b1fb592738f374ab9f8803"
+checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
 dependencies = [
- "axum 0.7.9",
+ "axum 0.8.8",
+ "base64 0.22.1",
  "mime_guess",
  "regex",
  "rust-embed",
  "serde",
  "serde_json",
  "url",
- "utoipa 5.4.0",
+ "utoipa",
  "utoipa-swagger-ui-vendored",
- "zip",
+ "zip 3.0.0",
 ]
 
 [[package]]
@@ -16089,6 +15813,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.13.0",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
 name = "zkhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16114,6 +15852,12 @@ dependencies = [
  "sha3",
  "subtle",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,56 +22,56 @@ publish = false
 rust-version = "1.93"
 
 [workspace.dependencies]
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1", features = [
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d", features = [
   "evm",
 ] }
-sov-accounts = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-api-spec = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-attester-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-chain-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-bank = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-blob-storage = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-paymaster = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-capabilities = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-cli = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-hyperlane-integration = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1", features = [
+sov-accounts = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-api-spec = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-attester-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-chain-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-bank = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-blob-storage = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-paymaster = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-capabilities = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-cli = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-hyperlane-integration = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d", features = [
   "evm",
 ] }
-sov-eth-client = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-test-state-consistency = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-ledger-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-modules-rollup-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-uniqueness = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-operator-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-prover-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-revenue-share = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-sequencer = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-sequencer-registry = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-soak-testing-lib = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-stf-runner = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-test-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-rollup-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-universal-wallet = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-zkvm-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-build = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-ethereum = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-evm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-soak-testing = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-eip712-auth = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-rest-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-proxy-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1", features = ["native"] }
+sov-eth-client = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-test-state-consistency = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-ledger-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-modules-rollup-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-uniqueness = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-operator-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-prover-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-revenue-share = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-sequencer = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-sequencer-registry = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-soak-testing-lib = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-stf-runner = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-test-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-rollup-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-universal-wallet = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-zkvm-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-build = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-ethereum = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-evm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-soak-testing = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-eip712-auth = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-rest-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-proxy-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d", features = ["native"] }
 
 
 stf-starter = { path = "./crates/stf", default-features = false }
@@ -85,7 +85,7 @@ alloy-consensus = { version = "1.1.0", default-features = false }
 alloy-primitives = { version = "1.4.1", default-features = false }
 alloy-rpc-types = { version = "1.0.41", default-features = false, features = ["eth"] }
 alloy-sol-types = { version = "1.4.1", default-features = false }
-axum = { version = "0.7.9", default-features = false }
+axum = { version = "0.8.8", default-features = false }
 serde = { version = "1.0.192", features = ["derive", "rc"] }
 serde_json = { version = "1.0" }
 

--- a/crates/provers/risc0/guest-celestia/Cargo.lock
+++ b/crates/provers/risc0/guest-celestia/Cargo.lock
@@ -30,17 +30,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "alloy-chains"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6068f356948cd84b5ad9ac30c50478e433847f14a50714d2b68f15d052724049"
-dependencies = [
- "alloy-primitives",
- "num_enum",
- "strum 0.27.2",
-]
-
-[[package]]
 name = "alloy-consensus"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,20 +53,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "thiserror 2.0.17",
-]
-
-[[package]]
-name = "alloy-consensus-any"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ead76c8c84ab3a50c31c56bc2c748c2d64357ad2131c32f9b10ab790a25e1a"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "serde",
 ]
 
 [[package]]
@@ -160,33 +135,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-genesis"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c25d5acb35706e683df1ea333c862bdb6b7c5548836607cd5bb56e501cca0b4f"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "alloy-serde",
- "alloy-trie",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "alloy-hardforks"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e29d7eacf42f89c21d7f089916d0bdb4f36139a31698790e8837d2dbbd4b2c3"
-dependencies = [
- "alloy-chains",
- "alloy-eip2124",
- "alloy-primitives",
- "auto_impl",
- "dyn-clone",
-]
-
-[[package]]
 name = "alloy-json-abi"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,19 +144,6 @@ dependencies = [
  "alloy-sol-type-parser",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "alloy-network-primitives"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e7918396eecd69d9c907046ec8a93fb09b89e2f325d5e7ea9c4e3929aa0dd2"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-serde",
- "serde",
 ]
 
 [[package]]
@@ -258,27 +193,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.110",
-]
-
-[[package]]
-name = "alloy-rpc-types-eth"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15e4831b71eea9d20126a411c1c09facf1d01d5cac84fd51d532d3c429cfc26"
-dependencies = [
- "alloy-consensus",
- "alloy-consensus-any",
- "alloy-eips",
- "alloy-network-primitives",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "alloy-sol-types",
- "itertools 0.14.0",
- "serde",
- "serde_json",
- "serde_with",
- "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -851,12 +765,11 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bcs"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b6598a2f5d564fb7855dc6b06fd1c38cff5a72bd8b863a4d021938497b440a"
+checksum = "302fd2afb39688efc82f6138a68861b8f04f95be5faab2a06805a8a49f28deb6"
 dependencies = [
- "serde",
- "thiserror 1.0.69",
+ "serde_core",
 ]
 
 [[package]]
@@ -1098,8 +1011,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -1250,15 +1161,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1317,12 +1219,6 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
-
-[[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-utils"
@@ -1543,7 +1439,6 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
- "convert_case 0.7.1",
  "proc-macro2",
  "quote",
  "syn 2.0.110",
@@ -2224,16 +2119,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2486,27 +2371,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
-name = "modular-bitfield"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53d79ba8304ac1c4f9eb3b9d281f21f7be9d4626f72ce7df4ad8fbde4f38a74"
-dependencies = [
- "modular-bitfield-impl",
- "static_assertions",
-]
-
-[[package]]
-name = "modular-bitfield-impl"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "multibase"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2537,7 +2401,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 
 [[package]]
 name = "nmt-rs"
@@ -2710,9 +2574,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c4b5ecbd0beec843101bffe848217f770e8b8da81d8355b7d6e226f2199b3dc"
 dependencies = [
- "alloy-rlp",
  "cfg-if",
- "proptest",
  "ruint",
  "serde",
  "smallvec",
@@ -2732,27 +2594,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-dependencies = [
- "critical-section",
- "portable-atomic",
-]
-
-[[package]]
-name = "op-alloy-consensus"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d7ec388eb83a3e6c71774131dbbb2ba9c199b6acac7dce172ed8de2f819e91"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "derive_more",
- "serde",
- "serde_with",
- "thiserror 2.0.17",
-]
 
 [[package]]
 name = "opaque-debug"
@@ -2905,22 +2746,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
 name = "platforms"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f21de1852251c849a53467e0ce8b97cca9d11fd4efa3930145c5d5f02f24447"
-
-[[package]]
-name = "portable-atomic"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "postcard"
@@ -3294,122 +3123,6 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
-
-[[package]]
-name = "reth-codecs"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-trie",
- "bytes",
- "modular-bitfield",
- "op-alloy-consensus",
- "reth-codecs-derive",
- "reth-zstd-compressors",
- "serde",
-]
-
-[[package]]
-name = "reth-codecs-derive"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.110",
-]
-
-[[package]]
-name = "reth-ethereum-forks"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-eip2124",
- "alloy-hardforks",
- "alloy-primitives",
- "auto_impl",
- "once_cell",
-]
-
-[[package]]
-name = "reth-ethereum-primitives"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "reth-codecs",
- "reth-primitives-traits",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "reth-primitives"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "once_cell",
- "reth-ethereum-forks",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
- "reth-static-file-types",
-]
-
-[[package]]
-name = "reth-primitives-traits"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-trie",
- "auto_impl",
- "bytes",
- "derive_more",
- "once_cell",
- "op-alloy-consensus",
- "reth-codecs",
- "revm-bytecode",
- "revm-primitives",
- "revm-state",
- "secp256k1 0.30.0",
- "serde",
- "serde_with",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "reth-static-file-types"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-primitives",
- "derive_more",
- "serde",
- "strum 0.27.2",
-]
-
-[[package]]
-name = "reth-zstd-compressors"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "zstd",
-]
 
 [[package]]
 name = "revm"
@@ -4303,7 +4016,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4317,7 +4030,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4335,7 +4048,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4355,7 +4068,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4366,7 +4079,7 @@ dependencies = [
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",
- "strum 0.26.3",
+ "strum",
  "thiserror 2.0.17",
  "tracing",
 ]
@@ -4374,7 +4087,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4394,7 +4107,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4406,7 +4119,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -4426,7 +4139,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4452,7 +4165,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4468,7 +4181,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "borsh",
  "derivative",
@@ -4502,7 +4215,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4520,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4533,9 +4246,6 @@ dependencies = [
  "derive_more",
  "hex",
  "itertools 0.14.0",
- "reth-ethereum-primitives",
- "reth-primitives",
- "reth-primitives-traits",
  "revm",
  "revm-database-interface",
  "schemars 0.8.22",
@@ -4559,7 +4269,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4573,14 +4283,14 @@ dependencies = [
  "sov-bank",
  "sov-modules-api",
  "sov-state",
- "strum 0.26.3",
+ "strum",
  "tracing",
 ]
 
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -4593,7 +4303,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4607,7 +4317,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4625,7 +4335,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4645,7 +4355,7 @@ dependencies = [
  "sov-rollup-interface",
  "sov-state",
  "sov-universal-wallet",
- "strum 0.26.3",
+ "strum",
  "thiserror 2.0.17",
  "toml",
  "tracing",
@@ -4655,12 +4365,12 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bech32",
  "blake2",
- "convert_case 0.6.0",
+ "convert_case",
  "darling",
  "derive_more",
  "hex",
@@ -4677,7 +4387,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4695,7 +4405,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4705,7 +4415,7 @@ dependencies = [
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",
- "strum 0.26.3",
+ "strum",
  "thiserror 2.0.17",
  "tracing",
 ]
@@ -4713,7 +4423,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4732,7 +4442,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4751,7 +4461,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4766,7 +4476,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4791,7 +4501,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4811,7 +4521,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4827,7 +4537,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4849,7 +4559,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4858,13 +4568,13 @@ dependencies = [
  "serde",
  "sov-modules-api",
  "sov-state",
- "strum 0.26.3",
+ "strum",
 ]
 
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4877,7 +4587,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4899,12 +4609,12 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "bech32",
  "borsh",
  "bs58",
- "convert_case 0.6.0",
+ "convert_case",
  "darling",
  "hex",
  "proc-macro2",
@@ -4916,7 +4626,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -4926,10 +4636,10 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
- "convert_case 0.6.0",
+ "convert_case",
 ]
 
 [[package]]
@@ -5021,7 +4731,7 @@ dependencies = [
  "sov-state",
  "sov-test-state-consistency",
  "sov-uniqueness",
- "strum 0.26.3",
+ "strum",
  "tracing",
  "value-setter",
 ]
@@ -5038,16 +4748,7 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-dependencies = [
- "strum_macros 0.27.2",
+ "strum_macros",
 ]
 
 [[package]]
@@ -5060,18 +4761,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.110",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
  "syn 2.0.110",
 ]
 
@@ -5821,32 +5510,4 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.110",
-]
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
 ]

--- a/crates/provers/risc0/guest-celestia/Cargo.toml
+++ b/crates/provers/risc0/guest-celestia/Cargo.toml
@@ -12,16 +12,16 @@ anyhow = { version = "1.0.95" }
 risc0-zkvm = { version = "2.1", default-features = false, features = ["std"] }
 risc0-zkvm-platform = { version = "2.0" }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["celestia_da"] }
 

--- a/crates/provers/risc0/guest-mock/Cargo.lock
+++ b/crates/provers/risc0/guest-mock/Cargo.lock
@@ -30,17 +30,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "alloy-chains"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6068f356948cd84b5ad9ac30c50478e433847f14a50714d2b68f15d052724049"
-dependencies = [
- "alloy-primitives",
- "num_enum",
- "strum 0.27.2",
-]
-
-[[package]]
 name = "alloy-consensus"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,20 +53,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "thiserror 2.0.17",
-]
-
-[[package]]
-name = "alloy-consensus-any"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ead76c8c84ab3a50c31c56bc2c748c2d64357ad2131c32f9b10ab790a25e1a"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "serde",
 ]
 
 [[package]]
@@ -160,33 +135,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-genesis"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c25d5acb35706e683df1ea333c862bdb6b7c5548836607cd5bb56e501cca0b4f"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "alloy-serde",
- "alloy-trie",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "alloy-hardforks"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e29d7eacf42f89c21d7f089916d0bdb4f36139a31698790e8837d2dbbd4b2c3"
-dependencies = [
- "alloy-chains",
- "alloy-eip2124",
- "alloy-primitives",
- "auto_impl",
- "dyn-clone",
-]
-
-[[package]]
 name = "alloy-json-abi"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,19 +144,6 @@ dependencies = [
  "alloy-sol-type-parser",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "alloy-network-primitives"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e7918396eecd69d9c907046ec8a93fb09b89e2f325d5e7ea9c4e3929aa0dd2"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-serde",
- "serde",
 ]
 
 [[package]]
@@ -258,27 +193,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.110",
-]
-
-[[package]]
-name = "alloy-rpc-types-eth"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15e4831b71eea9d20126a411c1c09facf1d01d5cac84fd51d532d3c429cfc26"
-dependencies = [
- "alloy-consensus",
- "alloy-consensus-any",
- "alloy-eips",
- "alloy-network-primitives",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "alloy-sol-types",
- "itertools 0.14.0",
- "serde",
- "serde_json",
- "serde_with",
- "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -851,12 +765,11 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bcs"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b6598a2f5d564fb7855dc6b06fd1c38cff5a72bd8b863a4d021938497b440a"
+checksum = "302fd2afb39688efc82f6138a68861b8f04f95be5faab2a06805a8a49f28deb6"
 dependencies = [
- "serde",
- "thiserror 1.0.69",
+ "serde_core",
 ]
 
 [[package]]
@@ -1098,8 +1011,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -1250,15 +1161,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1317,12 +1219,6 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
-
-[[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-utils"
@@ -1543,7 +1439,6 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
- "convert_case 0.7.1",
  "proc-macro2",
  "quote",
  "syn 2.0.110",
@@ -2367,16 +2262,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2635,27 +2520,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
-name = "modular-bitfield"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53d79ba8304ac1c4f9eb3b9d281f21f7be9d4626f72ce7df4ad8fbde4f38a74"
-dependencies = [
- "modular-bitfield-impl",
- "static_assertions",
-]
-
-[[package]]
-name = "modular-bitfield-impl"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "multibase"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2686,7 +2550,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 
 [[package]]
 name = "nmt-rs"
@@ -2859,9 +2723,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c4b5ecbd0beec843101bffe848217f770e8b8da81d8355b7d6e226f2199b3dc"
 dependencies = [
- "alloy-rlp",
  "cfg-if",
- "proptest",
  "ruint",
  "serde",
  "smallvec",
@@ -2881,27 +2743,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-dependencies = [
- "critical-section",
- "portable-atomic",
-]
-
-[[package]]
-name = "op-alloy-consensus"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d7ec388eb83a3e6c71774131dbbb2ba9c199b6acac7dce172ed8de2f819e91"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "derive_more",
- "serde",
- "serde_with",
- "thiserror 2.0.17",
-]
 
 [[package]]
 name = "opaque-debug"
@@ -3060,22 +2901,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
 name = "platforms"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f21de1852251c849a53467e0ce8b97cca9d11fd4efa3930145c5d5f02f24447"
-
-[[package]]
-name = "portable-atomic"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "postcard"
@@ -3458,122 +3287,6 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
-
-[[package]]
-name = "reth-codecs"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-trie",
- "bytes",
- "modular-bitfield",
- "op-alloy-consensus",
- "reth-codecs-derive",
- "reth-zstd-compressors",
- "serde",
-]
-
-[[package]]
-name = "reth-codecs-derive"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.110",
-]
-
-[[package]]
-name = "reth-ethereum-forks"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-eip2124",
- "alloy-hardforks",
- "alloy-primitives",
- "auto_impl",
- "once_cell",
-]
-
-[[package]]
-name = "reth-ethereum-primitives"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "reth-codecs",
- "reth-primitives-traits",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "reth-primitives"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "once_cell",
- "reth-ethereum-forks",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
- "reth-static-file-types",
-]
-
-[[package]]
-name = "reth-primitives-traits"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-trie",
- "auto_impl",
- "bytes",
- "derive_more",
- "once_cell",
- "op-alloy-consensus",
- "reth-codecs",
- "revm-bytecode",
- "revm-primitives",
- "revm-state",
- "secp256k1 0.30.0",
- "serde",
- "serde_with",
- "thiserror 2.0.17",
-]
-
-[[package]]
-name = "reth-static-file-types"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-primitives",
- "derive_more",
- "serde",
- "strum 0.27.2",
-]
-
-[[package]]
-name = "reth-zstd-compressors"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "zstd",
-]
 
 [[package]]
 name = "revm"
@@ -4467,7 +4180,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4481,7 +4194,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4499,7 +4212,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4519,7 +4232,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4530,7 +4243,7 @@ dependencies = [
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",
- "strum 0.26.3",
+ "strum",
  "thiserror 2.0.17",
  "tracing",
 ]
@@ -4538,7 +4251,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4558,7 +4271,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4570,7 +4283,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -4590,7 +4303,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4616,7 +4329,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4632,7 +4345,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "borsh",
  "derivative",
@@ -4646,7 +4359,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4664,7 +4377,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4677,9 +4390,6 @@ dependencies = [
  "derive_more",
  "hex",
  "itertools 0.14.0",
- "reth-ethereum-primitives",
- "reth-primitives",
- "reth-primitives-traits",
  "revm",
  "revm-database-interface",
  "schemars 0.8.22",
@@ -4703,7 +4413,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4717,14 +4427,14 @@ dependencies = [
  "sov-bank",
  "sov-modules-api",
  "sov-state",
- "strum 0.26.3",
+ "strum",
  "tracing",
 ]
 
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -4737,7 +4447,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4751,7 +4461,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4771,7 +4481,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4789,7 +4499,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4809,7 +4519,7 @@ dependencies = [
  "sov-rollup-interface",
  "sov-state",
  "sov-universal-wallet",
- "strum 0.26.3",
+ "strum",
  "thiserror 2.0.17",
  "toml",
  "tracing",
@@ -4819,12 +4529,12 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bech32",
  "blake2",
- "convert_case 0.6.0",
+ "convert_case",
  "darling",
  "derive_more",
  "hex",
@@ -4841,7 +4551,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4859,7 +4569,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4869,7 +4579,7 @@ dependencies = [
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",
- "strum 0.26.3",
+ "strum",
  "thiserror 2.0.17",
  "tracing",
 ]
@@ -4877,7 +4587,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4896,7 +4606,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4915,7 +4625,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4930,7 +4640,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4955,7 +4665,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4975,7 +4685,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4991,7 +4701,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5013,7 +4723,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -5022,13 +4732,13 @@ dependencies = [
  "serde",
  "sov-modules-api",
  "sov-state",
- "strum 0.26.3",
+ "strum",
 ]
 
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -5041,7 +4751,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -5063,12 +4773,12 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "bech32",
  "borsh",
  "bs58",
- "convert_case 0.6.0",
+ "convert_case",
  "darling",
  "hex",
  "proc-macro2",
@@ -5080,7 +4790,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -5090,10 +4800,10 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
- "convert_case 0.6.0",
+ "convert_case",
 ]
 
 [[package]]
@@ -5192,7 +4902,7 @@ dependencies = [
  "sov-state",
  "sov-test-state-consistency",
  "sov-uniqueness",
- "strum 0.26.3",
+ "strum",
  "tracing",
  "value-setter",
 ]
@@ -5209,16 +4919,7 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-dependencies = [
- "strum_macros 0.27.2",
+ "strum_macros",
 ]
 
 [[package]]
@@ -5231,18 +4932,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.110",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
  "syn 2.0.110",
 ]
 
@@ -6114,32 +5803,4 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.110",
-]
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
 ]

--- a/crates/provers/risc0/guest-mock/Cargo.toml
+++ b/crates/provers/risc0/guest-mock/Cargo.toml
@@ -15,16 +15,16 @@ risc0-zkvm-platform = { version = "2.0" }
 serde = { version = "1.0.188", features = ["derive", "rc"] }
 
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d", optional = true }
 
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["mock_da"] }

--- a/crates/provers/sp1/guest-celestia/Cargo.lock
+++ b/crates/provers/sp1/guest-celestia/Cargo.lock
@@ -56,17 +56,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "alloy-chains"
-version = "0.2.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e9e31d834fe25fe991b8884e4b9f0e59db4a97d86e05d1464d6899c013cd62"
-dependencies = [
- "alloy-primitives",
- "num_enum 0.7.6",
- "strum 0.27.2",
-]
-
-[[package]]
 name = "alloy-consensus"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,7 +68,6 @@ dependencies = [
  "alloy-trie",
  "alloy-tx-macros",
  "auto_impl",
- "borsh",
  "c-kzg",
  "derive_more 2.1.1",
  "either",
@@ -91,20 +79,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "alloy-consensus-any"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "118998d9015332ab1b4720ae1f1e3009491966a0349938a1f43ff45a8a4c6299"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "serde",
 ]
 
 [[package]]
@@ -200,34 +174,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-genesis"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf9480307b09d22876efb67d30cadd9013134c21f3a17ec9f93fd7536d38024"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "alloy-serde",
- "alloy-trie",
- "borsh",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "alloy-hardforks"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83ba208044232d14d4adbfa77e57d6329f51bc1acc21f5667bb7db72d88a0831"
-dependencies = [
- "alloy-chains",
- "alloy-eip2124",
- "alloy-primitives",
- "auto_impl",
- "dyn-clone",
-]
-
-[[package]]
 name = "alloy-json-abi"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,19 +183,6 @@ dependencies = [
  "alloy-sol-type-parser",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "alloy-network-primitives"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb82711d59a43fdfd79727c99f270b974c784ec4eb5728a0d0d22f26716c87ef"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-serde",
- "serde",
 ]
 
 [[package]]
@@ -299,27 +232,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "alloy-rpc-types-eth"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c095f92c4e1ff4981d89e9aa02d5f98c762a1980ab66bec49c44be11349da2"
-dependencies = [
- "alloy-consensus",
- "alloy-consensus-any",
- "alloy-eips",
- "alloy-network-primitives",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "alloy-sol-types",
- "itertools 0.14.0",
- "serde",
- "serde_json",
- "serde_with",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1008,12 +920,11 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bcs"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b6598a2f5d564fb7855dc6b06fd1c38cff5a72bd8b863a4d021938497b440a"
+checksum = "302fd2afb39688efc82f6138a68861b8f04f95be5faab2a06805a8a49f28deb6"
 dependencies = [
- "serde",
- "thiserror 1.0.69",
+ "serde_core",
 ]
 
 [[package]]
@@ -1333,8 +1244,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -3263,16 +3172,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3636,27 +3535,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
-name = "modular-bitfield"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53d79ba8304ac1c4f9eb3b9d281f21f7be9d4626f72ce7df4ad8fbde4f38a74"
-dependencies = [
- "modular-bitfield-impl",
- "static_assertions",
-]
-
-[[package]]
-name = "modular-bitfield-impl"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "mti"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3697,7 +3575,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 
 [[package]]
 name = "nmt-rs"
@@ -3936,9 +3814,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d49ff0c0d00d4a502b39df9af3a525e1efeb14b9dabb5bb83335284c1309210"
 dependencies = [
- "alloy-rlp",
  "cfg-if",
- "proptest",
  "ruint",
  "serde",
  "smallvec",
@@ -3958,33 +3834,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-dependencies = [
- "critical-section",
- "portable-atomic",
-]
 
 [[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "op-alloy-consensus"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726da827358a547be9f1e37c2a756b9e3729cb0350f43408164794b370cad8ae"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "derive_more 2.1.1",
- "serde",
- "serde_with",
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "opaque-debug"
@@ -4503,12 +4358,6 @@ dependencies = [
  "der",
  "spki",
 ]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
@@ -5057,122 +4906,6 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
-]
-
-[[package]]
-name = "reth-codecs"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-trie",
- "bytes",
- "modular-bitfield",
- "op-alloy-consensus",
- "reth-codecs-derive",
- "reth-zstd-compressors",
- "serde",
-]
-
-[[package]]
-name = "reth-codecs-derive"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "reth-ethereum-forks"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-eip2124",
- "alloy-hardforks",
- "alloy-primitives",
- "auto_impl",
- "once_cell",
-]
-
-[[package]]
-name = "reth-ethereum-primitives"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "reth-codecs",
- "reth-primitives-traits",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "reth-primitives"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "once_cell",
- "reth-ethereum-forks",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
- "reth-static-file-types",
-]
-
-[[package]]
-name = "reth-primitives-traits"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-trie",
- "auto_impl",
- "bytes",
- "derive_more 2.1.1",
- "once_cell",
- "op-alloy-consensus",
- "reth-codecs",
- "revm-bytecode",
- "revm-primitives",
- "revm-state",
- "secp256k1 0.30.0",
- "serde",
- "serde_with",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "reth-static-file-types"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-primitives",
- "derive_more 2.1.1",
- "serde",
- "strum 0.27.2",
-]
-
-[[package]]
-name = "reth-zstd-compressors"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "zstd",
 ]
 
 [[package]]
@@ -6545,7 +6278,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6559,7 +6292,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6577,7 +6310,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6597,7 +6330,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6616,7 +6349,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6636,7 +6369,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6648,7 +6381,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -6668,7 +6401,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6694,7 +6427,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6710,7 +6443,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "borsh",
  "derivative",
@@ -6743,7 +6476,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6761,7 +6494,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6774,9 +6507,6 @@ dependencies = [
  "derive_more 2.1.1",
  "hex",
  "itertools 0.14.0",
- "reth-ethereum-primitives",
- "reth-primitives",
- "reth-primitives-traits",
  "revm",
  "revm-database-interface",
  "schemars 0.8.22",
@@ -6800,7 +6530,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6821,7 +6551,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -6834,7 +6564,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6847,7 +6577,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6865,7 +6595,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6895,7 +6625,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6917,7 +6647,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6935,7 +6665,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6953,7 +6683,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6972,7 +6702,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6991,7 +6721,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7006,7 +6736,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7026,7 +6756,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7042,7 +6772,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7062,7 +6792,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7084,7 +6814,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7099,7 +6829,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7112,7 +6842,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -7134,7 +6864,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "bech32",
  "borsh",
@@ -7151,7 +6881,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -7161,7 +6891,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -9532,31 +9262,3 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
-]

--- a/crates/provers/sp1/guest-celestia/Cargo.toml
+++ b/crates/provers/sp1/guest-celestia/Cargo.toml
@@ -12,16 +12,16 @@ anyhow = { version = "1.0.95" }
 sp1-zkvm = { version = "6.0.2" }
 stf-starter = { path = "../../../stf", default-features = false, features = ["celestia_da"] }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d", optional = true }
 
 [patch.crates-io]
 sha2-v0-9-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.9.9-sp1-6.0.0" }

--- a/crates/provers/sp1/guest-mock/Cargo.lock
+++ b/crates/provers/sp1/guest-mock/Cargo.lock
@@ -56,17 +56,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "alloy-chains"
-version = "0.2.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e9e31d834fe25fe991b8884e4b9f0e59db4a97d86e05d1464d6899c013cd62"
-dependencies = [
- "alloy-primitives",
- "num_enum 0.7.6",
- "strum 0.27.2",
-]
-
-[[package]]
 name = "alloy-consensus"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,7 +68,6 @@ dependencies = [
  "alloy-trie",
  "alloy-tx-macros",
  "auto_impl",
- "borsh",
  "c-kzg",
  "derive_more 2.1.1",
  "either",
@@ -91,20 +79,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "alloy-consensus-any"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "118998d9015332ab1b4720ae1f1e3009491966a0349938a1f43ff45a8a4c6299"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "serde",
 ]
 
 [[package]]
@@ -200,34 +174,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-genesis"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf9480307b09d22876efb67d30cadd9013134c21f3a17ec9f93fd7536d38024"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "alloy-serde",
- "alloy-trie",
- "borsh",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "alloy-hardforks"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83ba208044232d14d4adbfa77e57d6329f51bc1acc21f5667bb7db72d88a0831"
-dependencies = [
- "alloy-chains",
- "alloy-eip2124",
- "alloy-primitives",
- "auto_impl",
- "dyn-clone",
-]
-
-[[package]]
 name = "alloy-json-abi"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,19 +183,6 @@ dependencies = [
  "alloy-sol-type-parser",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "alloy-network-primitives"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb82711d59a43fdfd79727c99f270b974c784ec4eb5728a0d0d22f26716c87ef"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-serde",
- "serde",
 ]
 
 [[package]]
@@ -299,27 +232,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "alloy-rpc-types-eth"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c095f92c4e1ff4981d89e9aa02d5f98c762a1980ab66bec49c44be11349da2"
-dependencies = [
- "alloy-consensus",
- "alloy-consensus-any",
- "alloy-eips",
- "alloy-network-primitives",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "alloy-sol-types",
- "itertools 0.14.0",
- "serde",
- "serde_json",
- "serde_with",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1008,12 +920,11 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bcs"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b6598a2f5d564fb7855dc6b06fd1c38cff5a72bd8b863a4d021938497b440a"
+checksum = "302fd2afb39688efc82f6138a68861b8f04f95be5faab2a06805a8a49f28deb6"
 dependencies = [
- "serde",
- "thiserror 1.0.69",
+ "serde_core",
 ]
 
 [[package]]
@@ -1333,8 +1244,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -3283,16 +3192,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3656,27 +3555,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
-name = "modular-bitfield"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53d79ba8304ac1c4f9eb3b9d281f21f7be9d4626f72ce7df4ad8fbde4f38a74"
-dependencies = [
- "modular-bitfield-impl",
- "static_assertions",
-]
-
-[[package]]
-name = "modular-bitfield-impl"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "mti"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3717,7 +3595,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 
 [[package]]
 name = "nmt-rs"
@@ -3956,9 +3834,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d49ff0c0d00d4a502b39df9af3a525e1efeb14b9dabb5bb83335284c1309210"
 dependencies = [
- "alloy-rlp",
  "cfg-if",
- "proptest",
  "ruint",
  "serde",
  "smallvec",
@@ -3978,33 +3854,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-dependencies = [
- "critical-section",
- "portable-atomic",
-]
 
 [[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "op-alloy-consensus"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726da827358a547be9f1e37c2a756b9e3729cb0350f43408164794b370cad8ae"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "derive_more 2.1.1",
- "serde",
- "serde_with",
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "opaque-debug"
@@ -4523,12 +4378,6 @@ dependencies = [
  "der",
  "spki",
 ]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
@@ -5077,122 +4926,6 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
-]
-
-[[package]]
-name = "reth-codecs"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-trie",
- "bytes",
- "modular-bitfield",
- "op-alloy-consensus",
- "reth-codecs-derive",
- "reth-zstd-compressors",
- "serde",
-]
-
-[[package]]
-name = "reth-codecs-derive"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "reth-ethereum-forks"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-eip2124",
- "alloy-hardforks",
- "alloy-primitives",
- "auto_impl",
- "once_cell",
-]
-
-[[package]]
-name = "reth-ethereum-primitives"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "reth-codecs",
- "reth-primitives-traits",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "reth-primitives"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "once_cell",
- "reth-ethereum-forks",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
- "reth-static-file-types",
-]
-
-[[package]]
-name = "reth-primitives-traits"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-trie",
- "auto_impl",
- "bytes",
- "derive_more 2.1.1",
- "once_cell",
- "op-alloy-consensus",
- "reth-codecs",
- "revm-bytecode",
- "revm-primitives",
- "revm-state",
- "secp256k1 0.30.0",
- "serde",
- "serde_with",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "reth-static-file-types"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "alloy-primitives",
- "derive_more 2.1.1",
- "serde",
- "strum 0.27.2",
-]
-
-[[package]]
-name = "reth-zstd-compressors"
-version = "1.9.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
-dependencies = [
- "zstd",
 ]
 
 [[package]]
@@ -6565,7 +6298,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6579,7 +6312,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6597,7 +6330,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6617,7 +6350,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6636,7 +6369,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6656,7 +6389,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6668,7 +6401,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -6688,7 +6421,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6714,7 +6447,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6730,7 +6463,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "borsh",
  "derivative",
@@ -6744,7 +6477,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6762,7 +6495,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6775,9 +6508,6 @@ dependencies = [
  "derive_more 2.1.1",
  "hex",
  "itertools 0.14.0",
- "reth-ethereum-primitives",
- "reth-primitives",
- "reth-primitives-traits",
  "revm",
  "revm-database-interface",
  "schemars 0.8.22",
@@ -6801,7 +6531,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6822,7 +6552,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -6835,7 +6565,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6848,7 +6578,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6868,7 +6598,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6886,7 +6616,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6916,7 +6646,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6938,7 +6668,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6956,7 +6686,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6974,7 +6704,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6993,7 +6723,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7012,7 +6742,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7027,7 +6757,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7047,7 +6777,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7063,7 +6793,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7083,7 +6813,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7105,7 +6835,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7120,7 +6850,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7133,7 +6863,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -7155,7 +6885,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "bech32",
  "borsh",
@@ -7172,7 +6902,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -7182,7 +6912,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=507882b140cb04b587c4636875fe7089a9861ba1#507882b140cb04b587c4636875fe7089a9861ba1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d#58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -9554,31 +9284,3 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
-]

--- a/crates/provers/sp1/guest-mock/Cargo.toml
+++ b/crates/provers/sp1/guest-mock/Cargo.toml
@@ -10,16 +10,16 @@ resolver = "2"
 anyhow = { version = "1.0.95" }
 sp1-zkvm = { version = "6.0.2" }
 serde = { version = "1.0.188", features = ["derive", "rc"] }
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "507882b140cb04b587c4636875fe7089a9861ba1", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "58d4d1de1a2e85c7a1c86f323d35994ee6c32a5d", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["mock_da"] }
 

--- a/crates/rollup/tests/test_helpers.rs
+++ b/crates/rollup/tests/test_helpers.rs
@@ -47,6 +47,7 @@ pub async fn start_rollup(
                 .expect("Prover address is not valid"),
             max_number_of_transitions_in_db: NonZeroU64::new(100).unwrap(),
             max_number_of_transitions_in_memory: NonZeroU64::new(20).unwrap(),
+            eager_proof_submission: true,
         },
         sequencer: SequencerConfig {
             max_allowed_node_distance_behind: 10,


### PR DESCRIPTION
## Summary
- Upgraded sovereign-sdk from `507882b` to `58d4d1d` (latest `dev` branch)
- Updated axum from 0.7.9 to 0.8.8 (SDK dependency upgrade)
- Added `eager_proof_submission` field to test `ProofManagerConfig`

## SDK changes included
- Axum 0.7 → 0.8 (+ utoipa 4→5, utoipa-swagger-ui 7→9)
- JMT storage removed (NOMT-only, already aligned in starter)
- `RollupProverConfig::Execute` variant removed (Skip/Prove only)
- `eager_proof_submission` config field added (defaults to `true`)
- Parallel proof request submission support
- bcs 0.2.0 upgrade

## Test plan
- [x] `make lint` passes
- [x] `make check` passes
- [x] `cargo nextest run` — 4/4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/rollup-starter/pull/159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
