### PR TITLE
Update to the latest dev 2026-04-14

### DIFF
--- a/.github/workflows/e2e-frontend.yml
+++ b/.github/workflows/e2e-frontend.yml
@@ -22,24 +22,17 @@ concurrency:
 jobs:
   build-rollup:
     name: "Build Rollup"
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x64-test-300gb-1-93;container.privileged=true;container.host-pid-namespace=true;overrides.cache-tag=starter-e2e-frontend
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo
-        uses: actions/cache@v4
+      - uses: namespacelabs/nscloud-cache-action@v1
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          cache: rust
 
       - name: Build rollup
+        env:
+          SKIP_GUEST_BUILD: "1"
         run: cargo build
 
       - name: Upload rollup binary
@@ -71,7 +64,7 @@ jobs:
           chmod +x ./bin/rollup
           ./bin/rollup &
           for i in {1..30}; do
-            curl -sf http://localhost:12346/health && break
+            curl -sf http://localhost:12346/healthcheck && break
             echo "Waiting for rollup... ($i)"
             sleep 2
           done
@@ -121,7 +114,7 @@ jobs:
           chmod +x ./bin/rollup
           ./bin/rollup &
           for i in {1..30}; do
-            curl -sf http://localhost:12346/health && break
+            curl -sf http://localhost:12346/healthcheck && break
             echo "Waiting for rollup... ($i)"
             sleep 2
           done

--- a/.github/workflows/reusable-job.yml
+++ b/.github/workflows/reusable-job.yml
@@ -45,53 +45,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v2
-        with:
-          version: "23.2"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
+          # TODO: Add NPM with locations
           cache: rust
-
-      - name: Install zepter
-        if: ${{ inputs.setup-zepter }}
-        uses: taiki-e/install-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tool: zepter@1
-
-      - name: Install nextest
-        if: ${{ inputs.setup-nextest }}
-        uses: taiki-e/install-action@nextest
-
-      - name: Install Bashtestmd
-        uses: taiki-e/install-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.github_token }}
-        with:
-          tool: bashtestmd@0.5
-
-      - name: Install risc0-zkvm toolchain
-        if: ${{ inputs.setup-risc0 }}
-        shell: bash
-        run: make install-risc0-toolchain
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install SP1 toolchain
-        if: ${{ inputs.setup-sp1 }}
-        shell: bash
-        env:
-          SHELL: /bin/bash
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: make install-sp1-toolchain
 
       - name: Run command
         env:

--- a/.github/workflows/reusable-job.yml
+++ b/.github/workflows/reusable-job.yml
@@ -9,22 +9,6 @@ on:
       command:
         required: true
         type: string
-      setup-sp1:
-        required: false
-        type: boolean
-        default: false
-      setup-risc0:
-        required: false
-        type: boolean
-        default: false
-      setup-nextest:
-        required: false
-        type: boolean
-        default: false
-      setup-zepter:
-        required: false
-        type: boolean
-        default: false
       env-vars:
         required: false
         type: string
@@ -47,8 +31,10 @@ jobs:
 
       - uses: namespacelabs/nscloud-cache-action@v1
         with:
-          # TODO: Add NPM with locations
           cache: rust
+          path: |
+            ~/.npm
+            examples/starter-js/node_modules
 
       - name: Run command
         env:

--- a/.github/workflows/reusable-job.yml
+++ b/.github/workflows/reusable-job.yml
@@ -29,10 +29,10 @@ on:
         required: false
         type: string
         default: ""
-      runner-size:
+      cache-tag:
         required: false
         type: string
-        default: "8x32"
+        default: "dev"
       check-dirty-tree:
         required: false
         type: boolean
@@ -41,12 +41,7 @@ on:
 jobs:
   run:
     name: ${{ inputs.job-name }}
-    runs-on:
-      - nscloud-ubuntu-22.04-amd64-${{ inputs.runner-size }}-with-cache
-      - nscloud-cache-tag-rollup-starter-build
-      - nscloud-cache-size-100gb
-      # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
-      - nscloud-exp-features:privileged;host-pid-namespace
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x64-test-300gb-1-93;container.privileged=true;container.host-pid-namespace=true;overrides.cache-tag=starter-${{ inputs.cache-tag }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,6 +50,7 @@ jobs:
       job-name: "Build Celestia SP1"
       env-vars: "SKIP_GUEST_BUILD=risc0 RUSTFLAGS='-D warnings'"
       command: "cargo build --no-default-features --features celestia_da,sp1"
+      cache-tag: 'celestia-sp1'
       setup-sp1: true
       check-dirty-tree: true
     secrets: inherit
@@ -60,6 +61,7 @@ jobs:
       job-name: "Build Celestia RISC0"
       env-vars: "SKIP_GUEST_BUILD=sp1 RUSTFLAGS='-D warnings'"
       command: "cargo build --no-default-features --features celestia_da,risc0"
+      cache-tag: 'celestia-risc0'
       setup-risc0: true
       check-dirty-tree: true
     secrets: inherit
@@ -70,7 +72,6 @@ jobs:
     with:
       job-name: "Run README"
       env-vars: "SKIP_GUEST_BUILD=1 RUSTFLAGS='-D warnings'"
-      runner-size: "16x64"
       command: |
         bashtestmd --input README.md --output scripts/rollup-starter.sh --tag=test-ci
         chmod +x scripts/rollup-starter.sh
@@ -84,7 +85,6 @@ jobs:
     with:
       job-name: "Run README_EXTERNAL_MOCK_DA"
       env-vars: "SKIP_GUEST_BUILD=1 RUSTFLAGS='-D warnings'"
-      runner-size: "16x64"
       command: |
         bashtestmd --input README_EXTERNAL_MOCK_DA.md --output scripts/rollup-starter-external-da.sh --tag=test-ci
         chmod +x scripts/rollup-starter-external-da.sh
@@ -93,12 +93,7 @@ jobs:
 
   docker-mock-da:
     name: "Docker Mock DA"
-    runs-on:
-      - nscloud-ubuntu-22.04-amd64-16x64-with-cache
-      - nscloud-cache-tag-rollup-starter-build
-      - nscloud-cache-size-100gb
-      # Privileged feature is needed for proper `io_uring` functionality needed by NOMT
-      - nscloud-exp-features:privileged;host-pid-namespace
+    runs-on: namespace-profile-sov-ubuntu-24-04-amd64-16x64-test-300gb-1-93;container.privileged=true;container.host-pid-namespace=true;overrides.cache-tag=starter-docker-mock-da
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-mock-da
@@ -111,7 +106,7 @@ jobs:
     with:
       job-name: "Run Celestia Tutorial"
       env-vars: "SKIP_GUEST_BUILD=1"
-      runner-size: "16x64"
+      cache-tag: "celestia"
       command: |
         bashtestmd --input GETTING_STARTED_WITH_CELESTIA.md --output scripts/rollup-starter-celestia.sh --tag=test-ci
         chmod +x scripts/rollup-starter-celestia.sh
@@ -124,7 +119,6 @@ jobs:
     with:
       job-name: "Run Hyperlane Tutorial"
       env-vars: "SKIP_GUEST_BUILD=1"
-      runner-size: "16x64"
       command: |
         bashtestmd --input GETTING_STARTED_WITH_HYPERLANE.md --output scripts/rollup-starter-hyperlane.sh --tag=test-ci
         chmod +x scripts/rollup-starter-hyperlane.sh

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,6 @@ jobs:
       # Lints native project, but also compiles guests on bare metal.
       # This to enforce update of Cargo.lock fo guests
       command: "make lint && make check"
-      setup-zepter: true
       check-dirty-tree: true
     secrets: inherit
 
@@ -38,9 +37,6 @@ jobs:
     with:
       job-name: "Test"
       command: "cargo nextest run"
-      setup-sp1: true
-      setup-risc0: true
-      setup-nextest: true
       check-dirty-tree: true
     secrets: inherit
 
@@ -51,7 +47,6 @@ jobs:
       env-vars: "SKIP_GUEST_BUILD=risc0 RUSTFLAGS='-D warnings'"
       command: "cargo build --no-default-features --features celestia_da,sp1"
       cache-tag: 'celestia-sp1'
-      setup-sp1: true
       check-dirty-tree: true
     secrets: inherit
 
@@ -62,7 +57,6 @@ jobs:
       env-vars: "SKIP_GUEST_BUILD=sp1 RUSTFLAGS='-D warnings'"
       command: "cargo build --no-default-features --features celestia_da,risc0"
       cache-tag: 'celestia-risc0'
-      setup-risc0: true
       check-dirty-tree: true
     secrets: inherit
 

--- a/.github/workflows/soak-test.yml
+++ b/.github/workflows/soak-test.yml
@@ -30,7 +30,7 @@ jobs:
     with:
       job-name: "Soak Test"
       env-vars: "SKIP_GUEST_BUILD=1"
-      runner-size: "16x64"
+      cache-tag: "soak"
       command: |
         cargo build --release
         cargo build --release --bin rollup-starter-soak-test -p rollup-starter-soak-test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2590,9 +2590,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-client"
-version = "0.5.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7531886eef1f65e30ba676dba429c98965fb03a3fcf94d8468fecabdc45259"
+checksum = "842d4da28a797bd47887d58f706a437d46793e21d4d68fccc4369902859c5623"
 dependencies = [
  "async-stream",
  "blockstore",
@@ -2618,11 +2618,12 @@ dependencies = [
 
 [[package]]
 name = "celestia-grpc"
-version = "0.12.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3d17a7cd950e6387bfb7aa494ab23989035763261a1bb725ef4430a2645ade"
+checksum = "af6ad6c32de15bf76e4be4dc837dd6e1a55de5ad36614bf24b871d65ef240521"
 dependencies = [
  "arc-swap",
+ "async-trait",
  "bytes",
  "celestia-grpc-macros",
  "celestia-proto",
@@ -2647,6 +2648,7 @@ dependencies = [
  "tendermint-proto",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tonic 0.13.1",
  "tonic-web-wasm-client",
  "tracing",
@@ -2657,9 +2659,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-grpc-macros"
-version = "0.7.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d79e42455c42517ad6a7c3bc301640e534ccf37e1e37777b4a3ea12bca93d2a"
+checksum = "c7b4e40558271aaa06bad923a86dd2576b86a62f08207f69989bb927197a0371"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2668,9 +2670,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-proto"
-version = "0.12.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65013505b04171f213d833b92bb076e9f229c36e5d144cb2faf25378397e2597"
+checksum = "8fba8cece7d46d57382503455ed2847aef638dd99d6ecc96c72f61680e571c6b"
 dependencies = [
  "bytes",
  "prost 0.13.5",
@@ -2687,15 +2689,16 @@ dependencies = [
 
 [[package]]
 name = "celestia-rpc"
-version = "0.16.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71f5f1ededb6d3398c6f922ad543594b0706d2de19e02d97024037cb750dbd89"
+checksum = "b5db3d3b394f8f8058134263bac9e4267c9fd98a5842d5baad6f544627823f45"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
  "celestia-proto",
  "celestia-types",
  "futures-util",
+ "getrandom 0.3.4",
  "gloo-net",
  "gloo-timers 0.3.0",
  "http 1.4.0",
@@ -2713,9 +2716,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.20.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe616393f4c88756ed6b8097167a623c6e4e48e2a3d75109e3ea5d5941587e0"
+checksum = "394ae3bd14f0a3792c312fd0ffc1a1719fd3c8d28cf1f8016afd01cce6197001"
 dependencies = [
  "base64 0.22.1",
  "bech32",
@@ -6213,9 +6216,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lumina-utils"
-version = "0.5.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e68ba51207213b3fa8a42465526efdbe6c3c983a78a2a972d3a8e94d2bf9ab8"
+checksum = "e13be66015388d059c1c9f95de2508329c4a9ed6e563b7a3423fcd92ffbba3bf"
 dependencies = [
  "futures",
  "gloo-timers 0.3.0",
@@ -6223,7 +6226,10 @@ dependencies = [
  "pin-project",
  "send_wrapper 0.6.0",
  "tokio",
+ "tokio-util",
  "tonic 0.13.1",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-time",
 ]
 
@@ -6599,7 +6605,7 @@ dependencies = [
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 
 [[package]]
 name = "nix"
@@ -9380,7 +9386,7 @@ dependencies = [
 [[package]]
 name = "rockbound"
 version = "0.1.0"
-source = "git+https://github.com/sovereign-labs/rockbound?rev=d12aa6c0e0c7935e5abc6c7620d3835faba30756#d12aa6c0e0c7935e5abc6c7620d3835faba30756"
+source = "git+https://github.com/sovereign-labs/rockbound?rev=00d4a84f0b9256da681e2138949e01e4c138a5ae#00d4a84f0b9256da681e2138949e01e4c138a5ae"
 dependencies = [
  "anyhow",
  "parking_lot",
@@ -11045,7 +11051,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11060,7 +11066,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -11081,7 +11087,7 @@ dependencies = [
 [[package]]
 name = "sov-api-spec"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "backon",
@@ -11105,7 +11111,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11126,7 +11132,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11147,7 +11153,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-sender"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11170,7 +11176,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11190,7 +11196,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11202,7 +11208,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -11222,7 +11228,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11256,7 +11262,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11272,7 +11278,7 @@ dependencies = [
 [[package]]
 name = "sov-cli"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11295,7 +11301,7 @@ dependencies = [
 [[package]]
 name = "sov-db"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11331,7 +11337,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -11349,7 +11355,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11367,7 +11373,7 @@ dependencies = [
 [[package]]
 name = "sov-eth-client"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -11395,7 +11401,7 @@ dependencies = [
 [[package]]
 name = "sov-eth-dev-signer"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11406,7 +11412,7 @@ dependencies = [
 [[package]]
 name = "sov-ethereum"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11437,7 +11443,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11479,7 +11485,7 @@ dependencies = [
 [[package]]
 name = "sov-evm-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -11495,7 +11501,7 @@ dependencies = [
 [[package]]
 name = "sov-full-node-configs"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "schemars 0.8.22",
@@ -11509,7 +11515,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11533,7 +11539,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -11547,7 +11553,7 @@ dependencies = [
 [[package]]
 name = "sov-ledger-apis"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11572,7 +11578,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -11595,7 +11601,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11628,7 +11634,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11648,7 +11654,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11695,7 +11701,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bech32",
@@ -11717,7 +11723,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-rollup-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11756,7 +11762,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11777,7 +11783,7 @@ dependencies = [
 [[package]]
 name = "sov-node-client"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11796,7 +11802,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11814,7 +11820,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11836,7 +11842,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11855,7 +11861,7 @@ dependencies = [
 [[package]]
 name = "sov-proxy-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11872,7 +11878,7 @@ dependencies = [
 [[package]]
 name = "sov-rest-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11896,7 +11902,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11911,7 +11917,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11940,7 +11946,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-apis"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "axum 0.8.8",
  "base64 0.22.1",
@@ -11967,7 +11973,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -12013,7 +12019,7 @@ dependencies = [
 [[package]]
 name = "sov-rpc-eth-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12035,7 +12041,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12085,7 +12091,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -12118,7 +12124,7 @@ dependencies = [
 [[package]]
 name = "sov-soak-testing-lib"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12140,7 +12146,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -12164,7 +12170,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -12192,7 +12198,7 @@ dependencies = [
 [[package]]
 name = "sov-stf-runner"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12226,7 +12232,7 @@ dependencies = [
 [[package]]
 name = "sov-synthetic-load"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12244,7 +12250,7 @@ dependencies = [
 [[package]]
 name = "sov-test-modules"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12263,7 +12269,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12278,7 +12284,7 @@ dependencies = [
 [[package]]
 name = "sov-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12338,7 +12344,7 @@ dependencies = [
 [[package]]
 name = "sov-transaction-generator"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12372,7 +12378,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12385,7 +12391,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -12407,7 +12413,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "bech32",
  "borsh",
@@ -12424,7 +12430,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -12434,7 +12440,7 @@ dependencies = [
 [[package]]
 name = "sov-value-setter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12460,7 +12466,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,7 +462,7 @@ dependencies = [
  "rand 0.9.2",
  "rapidhash",
  "ruint",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "serde",
  "sha3",
 ]
@@ -1335,7 +1335,7 @@ dependencies = [
  "futures-core",
  "libc",
  "portable-atomic",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "tokio",
  "tokio-stream",
  "xattr",
@@ -2117,26 +2117,6 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
-dependencies = [
- "bitflags 2.11.0",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -2144,11 +2124,11 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "shlex",
  "syn 2.0.117",
 ]
@@ -2817,7 +2797,6 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading",
 ]
 
 [[package]]
@@ -3147,6 +3126,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crash-context"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031ed29858d90cfdf27fe49fae28028a1f20466db97962fa2f4ea34809aeebf3"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "mach2",
+]
+
+[[package]]
+name = "crash-handler"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0df5c9639f4942eb7702b964b3f9adf03a55724a57558cc177407388a8b936e2"
+dependencies = [
+ "cfg-if",
+ "crash-context",
+ "libc",
+ "mach2",
+ "parking_lot",
 ]
 
 [[package]]
@@ -3536,7 +3539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5779,7 +5782,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand 0.9.2",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -6019,16 +6022,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
-
-[[package]]
 name = "liblzma"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6072,7 +6065,7 @@ version = "0.17.3+10.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
  "bzip2-sys",
  "cc",
  "libc",
@@ -6240,6 +6233,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
 dependencies = [
  "cc",
+ "libc",
+]
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
  "libc",
 ]
 
@@ -6605,7 +6607,7 @@ dependencies = [
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 
 [[package]]
 name = "nix"
@@ -8090,7 +8092,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -8241,7 +8243,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls 0.23.37",
  "socket2 0.6.3",
  "thiserror 2.0.18",
@@ -8261,7 +8263,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls 0.23.37",
  "rustls-pki-types",
  "slab",
@@ -9633,12 +9635,6 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -10559,18 +10555,18 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-air"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "242539aba9e5424923d7bd629775570c7d10ec28584e96ea599575a51bedcde8"
+checksum = "9bfd4c0fb41e0638afd60ce2ebf74d59225e3c20e25b8f202912c8a38f793de4"
 dependencies = [
  "p3-air",
 ]
 
 [[package]]
 name = "slop-algebra"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "691beea96fd18d4881f9ca1cb4e58194dac6366f24956a2fdae00c8ee382a0c9"
+checksum = "733912d564a68ff209707e71fdc517d4ff82d4362b6a409f6a8241dfcb7a576a"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -10579,9 +10575,9 @@ dependencies = [
 
 [[package]]
 name = "slop-alloc"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b7800cba9b31377f9353174d13fd8e39608b6f1d1531f0e92b8ce4af49ae0"
+checksum = "0ee6cc091290f9db6e3d3452430970f5234dbd270541300c9554d8172e18d0c2"
 dependencies = [
  "serde",
  "slop-algebra",
@@ -10590,9 +10586,9 @@ dependencies = [
 
 [[package]]
 name = "slop-baby-bear"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949e3c822532a87b4ad04f7280283c256621b0a83aee1b40cbd721df29df641d"
+checksum = "3f0138bae78c3d8f1691ee28315dd87b3d71c0b71e51e7b9eabf8d2e6ffffcfa"
 dependencies = [
  "lazy_static",
  "p3-baby-bear",
@@ -10605,9 +10601,9 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58984f92091a668a006b6895487079d99209e599b02d636f061fe4ae26977fb5"
+checksum = "272d5e3082f066bcdd6ded60e3dd403a7697f4bbfaeea4c4e00f088bd555305e"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -10628,9 +10624,9 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold-prover"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86eb8581b52f97860242fe5e8d6b49d2a37e1b38d4a647adf24acaa2965ee7d"
+checksum = "175433ed8fc9a45fcb835b4375bbe54c5df0022b920f248055da6ae99e141104"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -10655,9 +10651,9 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1852499c245f7f3dec23408b4930b3ea7570ae914b9c31f12950ac539d85ee"
+checksum = "a71b23ede427299e139fb822c5d0ea8fb931dc297eba0c6e2f30f774c04ebc81"
 dependencies = [
  "ff 0.13.1",
  "p3-bn254-fr",
@@ -10671,9 +10667,9 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4349af93602f3876a3eda948a74d9d16d774c401dfe25f41a45ffd84f230bc1"
+checksum = "59e4993210936ab317c0d56ee8257e1cdfe6c2fae4df1e158737f034e21d45f9"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -10684,9 +10680,9 @@ dependencies = [
 
 [[package]]
 name = "slop-commit"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584339690d20fb6b34b0dc957cbd267221ba2ab7b0c1292c118378f3498979c4"
+checksum = "afe1a49612ffedb6a44825ccbaa54ea53670a61366b8112a80865fef462630f9"
 dependencies = [
  "p3-commit",
  "serde",
@@ -10695,9 +10691,9 @@ dependencies = [
 
 [[package]]
 name = "slop-dft"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "148281e1611ca570d016a733aac2f3ec9867241cc800a96d15bc6ecfd010daf7"
+checksum = "b1fe8ca56f2cb47f22658f923e8d1a97413bb89ecc4e7185722ec406e61b82e9"
 dependencies = [
  "p3-dft",
  "serde",
@@ -10709,18 +10705,18 @@ dependencies = [
 
 [[package]]
 name = "slop-fri"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0857a346ea28496ee56b1dcad192db8c7ff0455a18bfd67ce6513323b594b746"
+checksum = "434a8e3f5fc6c5a1973a3c3964b4589af26c74bd480fd7cd6dcb0feb7d7e8f92"
 dependencies = [
  "p3-fri",
 ]
 
 [[package]]
 name = "slop-futures"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bbfea5447d243572da7aae8d5e57856229a97fb8bc6a42439d4c5f4de951ee0"
+checksum = "69e76ea10d2865798d6a9c39faffbc2c23c0bbf34a6e449e83de409aa265171a"
 dependencies = [
  "crossbeam",
  "futures",
@@ -10733,9 +10729,9 @@ dependencies = [
 
 [[package]]
 name = "slop-jagged"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc420430b93d38e9aae903bc4bc11c342f8d49d015cca26eeb36a6ea3f7a0f1f"
+checksum = "8677ede7f5b5f1fa19884ba07b6120cbb74b4e4ff4cb56cd068e01fffd4e603b"
 dependencies = [
  "derive-where",
  "futures",
@@ -10767,18 +10763,18 @@ dependencies = [
 
 [[package]]
 name = "slop-keccak-air"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "288abf40d9901f79e221ece87f11324826289bf5d694fde07dd785bdb4afda38"
+checksum = "794162816eb0c8869f2bf09881ac6a7c808da1aab11e097ca25460e4ef895cc7"
 dependencies = [
  "p3-keccak-air",
 ]
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "574784c044d11cf9d8238dc18bce9b897bc34d0fb1daaceafd75ebb400084016"
+checksum = "8986e94b9a43d58fc8ce5bf111b0985479ab888ced923e3052fb19943f7859b4"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -10791,27 +10787,27 @@ dependencies = [
 
 [[package]]
 name = "slop-matrix"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd1117c395388bd172826115ac4f9a7e09bf9c937ceafa82194132a058e27c0d"
+checksum = "a89bef0d6e09bc5431c6b50b3eee460722ca9eb569dffcdec582bd1d72db496c"
 dependencies = [
  "p3-matrix",
 ]
 
 [[package]]
 name = "slop-maybe-rayon"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81316cfe721c3f47cd0af63002a8b6557c951ff9588fa7db0f4f3b99af091486"
+checksum = "e135011bcdae048b9e85f42ba95cc8dc69cb4f5566289044cabe67a6ac65e6e0"
 dependencies = [
  "p3-maybe-rayon",
 ]
 
 [[package]]
 name = "slop-merkle-tree"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e700652778c15320f6269362103b87a3787a7c9d70fb05d9742dbce66c46f764"
+checksum = "748e3fb2d76fd2e2017d9e544072a8318efc1deac6277b5721d31381a674d505"
 dependencies = [
  "derive-where",
  "ff 0.13.1",
@@ -10830,15 +10826,16 @@ dependencies = [
  "slop-poseidon2",
  "slop-symmetric",
  "slop-tensor",
+ "slop-utils",
  "thiserror 1.0.69",
  "zkhash",
 ]
 
 [[package]]
 name = "slop-multilinear"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6151db452ace0d960314f46c61a2b8d45e1fa4dfd5830447c67fc1e1e1e823b5"
+checksum = "b579ce845ca26e0c2750d11f09327add269e4b695c21b35f1659f49b9bd08311"
 dependencies = [
  "derive-where",
  "futures",
@@ -10857,27 +10854,27 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5af617970b63e8d7199204bc02996745b6c35c39f2b513a118c62c7b1a0b2f1b"
+checksum = "5b06e4a24cba104a0a39740eedd97e60e8896926cc38e6a58d5866cc9811affa"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58d82c53508f3ebff8acdabb5db2584f37686257a2549a17c977cf30cd9e24e6"
+checksum = "0b0b66701c82f6aab97f4990b5d9ed7463beb5b5042dbe5eda5f6c71a6207b35"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-stacked"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a25c9fb9c908a2d10037934e2c299d30f98a2146f6ded87a7b529b05ddbfda27"
+checksum = "8992c338b13abe792faf62000a47096f08817ea655036c530990b1c60c5ff256"
 dependencies = [
  "derive-where",
  "futures",
@@ -10898,9 +10895,9 @@ dependencies = [
 
 [[package]]
 name = "slop-sumcheck"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c691f34c05e933777059a10804e00f77834b927abc2701f5f394e9c2b49c1c"
+checksum = "45fdcab8b7e0fa43b808112fd1c387eabfa7e09435c6a4fb92e45b917971ade8"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -10916,18 +10913,18 @@ dependencies = [
 
 [[package]]
 name = "slop-symmetric"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15acfa7f567ffa4f36de134492632a397c33fa6af2e48894e50978b52eeeb871"
+checksum = "e6d159948b924fd00f280064d7a049e43dceb2f26067f32fb99570d3169969ee"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "slop-tensor"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1796e5ff7dcdcd2c15f423a27550a4688e25009bd5ca648d9593d66f243950d6"
+checksum = "f0a6b65130a06d1b1a24ab4928e1eadc5a6e14f35c171c0e69d5b9cf6c4d56e9"
 dependencies = [
  "arrayvec",
  "derive-where",
@@ -10945,18 +10942,18 @@ dependencies = [
 
 [[package]]
 name = "slop-uni-stark"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504f32330985e48a6aa9c9e0985641a4dc084d3843ff59075591b24b818f2a67"
+checksum = "b3655347bb0dc0e559a63fa8c5053a79d9d0258af04b6b3bebfc51fff880416a"
 dependencies = [
  "p3-uni-stark",
 ]
 
 [[package]]
 name = "slop-utils"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba510663661800990c1207ddbf3a1e67a551f05d882a60197adbb19c6824754f"
+checksum = "4fad36458e05b6ccc8ebe951734e9d036128eb0f01596824e1104a37b3216654"
 dependencies = [
  "p3-util",
  "tracing-forest",
@@ -10965,9 +10962,9 @@ dependencies = [
 
 [[package]]
 name = "slop-whir"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71f6a16450fc701450831121810da91c6ee3ac50e4705327dcd4957b046015a"
+checksum = "d104106013cf050132b47d73568b4562e273c0dda3a1d304a96afab25737d414"
 dependencies = [
  "derive-where",
  "futures",
@@ -11051,7 +11048,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11066,7 +11063,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -11087,7 +11084,7 @@ dependencies = [
 [[package]]
 name = "sov-api-spec"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "backon",
@@ -11111,7 +11108,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11132,7 +11129,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11153,7 +11150,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-sender"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11176,7 +11173,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11196,7 +11193,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11208,7 +11205,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -11228,7 +11225,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11262,7 +11259,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11278,7 +11275,7 @@ dependencies = [
 [[package]]
 name = "sov-cli"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11301,7 +11298,7 @@ dependencies = [
 [[package]]
 name = "sov-db"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11337,7 +11334,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -11355,7 +11352,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11373,7 +11370,7 @@ dependencies = [
 [[package]]
 name = "sov-eth-client"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -11401,7 +11398,7 @@ dependencies = [
 [[package]]
 name = "sov-eth-dev-signer"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11412,7 +11409,7 @@ dependencies = [
 [[package]]
 name = "sov-ethereum"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11443,7 +11440,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11485,7 +11482,7 @@ dependencies = [
 [[package]]
 name = "sov-evm-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -11501,7 +11498,7 @@ dependencies = [
 [[package]]
 name = "sov-full-node-configs"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "schemars 0.8.22",
@@ -11515,7 +11512,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11539,7 +11536,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -11553,7 +11550,7 @@ dependencies = [
 [[package]]
 name = "sov-ledger-apis"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11578,7 +11575,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -11601,7 +11598,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11634,7 +11631,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11654,7 +11651,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11701,7 +11698,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bech32",
@@ -11723,7 +11720,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-rollup-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11762,7 +11759,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11783,7 +11780,7 @@ dependencies = [
 [[package]]
 name = "sov-node-client"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11802,7 +11799,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11820,7 +11817,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11842,7 +11839,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11861,7 +11858,7 @@ dependencies = [
 [[package]]
 name = "sov-proxy-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11878,7 +11875,7 @@ dependencies = [
 [[package]]
 name = "sov-rest-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11902,7 +11899,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11917,7 +11914,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11946,7 +11943,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-apis"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "axum 0.8.8",
  "base64 0.22.1",
@@ -11973,7 +11970,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -12019,7 +12016,7 @@ dependencies = [
 [[package]]
 name = "sov-rpc-eth-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12041,7 +12038,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12091,7 +12088,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -12124,7 +12121,7 @@ dependencies = [
 [[package]]
 name = "sov-soak-testing-lib"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12146,7 +12143,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -12170,7 +12167,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -12198,7 +12195,7 @@ dependencies = [
 [[package]]
 name = "sov-stf-runner"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12232,7 +12229,7 @@ dependencies = [
 [[package]]
 name = "sov-synthetic-load"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12250,7 +12247,7 @@ dependencies = [
 [[package]]
 name = "sov-test-modules"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12269,7 +12266,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12284,7 +12281,7 @@ dependencies = [
 [[package]]
 name = "sov-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12344,7 +12341,7 @@ dependencies = [
 [[package]]
 name = "sov-transaction-generator"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12378,7 +12375,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12391,7 +12388,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -12413,7 +12410,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "bech32",
  "borsh",
@@ -12430,7 +12427,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -12440,7 +12437,7 @@ dependencies = [
 [[package]]
 name = "sov-value-setter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12466,7 +12463,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -12474,9 +12471,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38fe5854ea3054c20b34fe85b08437583174e8cd71e612fcfef67ea841daea14"
+checksum = "7321136acefff985b0fb201b84359d609451bbd0a63203d4b601eaabe28da14f"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.18.1",
@@ -12488,9 +12485,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc9268de48a534ccb82287a517c0a07ee594136bc9fce6c7eb438c69e7917be"
+checksum = "89e911afd7e96cab3936e275445e23d1e6cb26776bd06223cb4466e812b13b54"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -12527,10 +12524,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp1-core-machine"
-version = "6.0.2"
+name = "sp1-core-executor-runner"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d436300d3052341854e58c88a9b5444a6f45689ee8933f9bec047ac367693182"
+checksum = "b3bf24cda2b466c097e62a60a3e1ac7ff014d7972f4ff350d72ff2b89eff5128"
+dependencies = [
+ "base64 0.22.1",
+ "bincode",
+ "cargo_metadata 0.18.1",
+ "hashbrown 0.14.5",
+ "hex",
+ "libc",
+ "sha2 0.10.9",
+ "sp1-core-executor",
+ "sp1-core-executor-runner-binary",
+ "sp1-jit",
+ "sp1-primitives",
+ "sysinfo",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "sp1-core-executor-runner-binary"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf22b7b1696ce686f79efb99a543a10b0b82d1068834087d21f0fe3d76d9054d"
+dependencies = [
+ "bincode",
+ "crash-handler",
+ "libc",
+ "serde",
+ "sp1-core-executor",
+ "sp1-jit",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
+name = "sp1-core-machine"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fd9328937306a831184febaae80c7b63ee15d3716573f0a34d62f5dee7408d"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -12556,6 +12590,7 @@ dependencies = [
  "slop-uni-stark",
  "snowbridge-amcl",
  "sp1-core-executor",
+ "sp1-core-executor-runner",
  "sp1-curves",
  "sp1-derive",
  "sp1-hypercube",
@@ -12574,31 +12609,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp1-cuda"
-version = "6.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a03bb846daaabe6e94af5e5199aa110b42c68482d6380b7e765d9d6b65119d52"
-dependencies = [
- "bincode",
- "bytes",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "sp1-core-executor",
- "sp1-core-machine",
- "sp1-primitives",
- "sp1-prover",
- "sp1-prover-types",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "sp1-curves"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e3ad4fc0f5ea7286fbe5c788d97125dc0cb40eb81f15becb432a65f350cd2f9"
+checksum = "bf1e420a0980906ff8f875525664209395c7a5243243ff70283adb357e921ef2"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -12617,9 +12631,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f111a90749619066fbd7ba102b22375bc6c824abb66804c3184ba0f650d017a2"
+checksum = "caa1235972b67b86514c3f23ba690972b712dd009159c2e50f723d7ac02173d8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12628,9 +12642,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-hypercube"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caff340db83b2c38b01f022624b8b792c38f201417581d6855dbe9a445d2485f"
+checksum = "b8314d1620d659913912121a3ecae19d1384fdd06e43d954034cad8bd082f5db"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -12676,12 +12690,13 @@ dependencies = [
 
 [[package]]
 name = "sp1-jit"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcadaa9206d36ae953c1b4390373879281ef1423115aa180e7ef0e82259d92aa"
+checksum = "7e6b9a7102c21e5ecd5b65861188f068f17951a2db9bc3fd4f65cd5f9b0e8449"
 dependencies = [
  "dynasmrt",
  "hashbrown 0.14.5",
+ "libc",
  "memfd",
  "memmap2",
  "serde",
@@ -12691,9 +12706,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517e820776910468611149dda66791bdb700c1b7d68b96f0ea2e604f00ad8771"
+checksum = "9b96392c1b1c197beaa6b0806099a8d73643a09d5ac0874e26c9c5153a7fcb4c"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -12703,9 +12718,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f395525b4fc46d37136f45be264c81718a67f4409c14c547ff491a263e019e7"
+checksum = "b6b77098dae9d62e080be3af253188c08e7e96e666423306654eede0110bf363"
 dependencies = [
  "bincode",
  "blake3",
@@ -12727,15 +12742,14 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64545387a6b5ee58155d75183223a8f19961e23d76a13a49c16514896e52ff7"
+checksum = "d4ba1691f53df50f8024f756c3a0e7b009e544e31c7297ae591eceba1d27232c"
 dependencies = [
  "anyhow",
  "bincode",
  "clap",
  "dirs 5.0.1",
- "downloader",
  "either",
  "enum-map",
  "eyre",
@@ -12766,6 +12780,7 @@ dependencies = [
  "slop-stacked",
  "slop-symmetric",
  "sp1-core-executor",
+ "sp1-core-executor-runner",
  "sp1-core-machine",
  "sp1-derive",
  "sp1-hypercube",
@@ -12791,9 +12806,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover-types"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "834512266314b8dd35fd52b921d62abb113c3c35b27358acdbc178b3a17ec72e"
+checksum = "011fe0b63d8b930665e5e6ca5f9f766c1b442727ec473d0baeea629d225c4360"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -12812,9 +12827,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "105531a782d66030eab608832e0829e4699053a6d41cd3c2c7931def9c9540fb"
+checksum = "ae1bb2594e6480d20c6d4be6099408df3a0de85bc956f0e74511c80515ac9e2d"
 dependencies = [
  "bincode",
  "itertools 0.14.0",
@@ -12852,9 +12867,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ab98d241444285539b0d4203288fbe9887707c355e346cfb176b461524c58d"
+checksum = "8e113c225149badeda05e679f169281cad6ef0480919f726e21acdfbf38848fb"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -12873,9 +12888,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-executor"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc69767dce218874edbef09515ccc5fb32d5e6b857a95a99944a66f6f405f5b1"
+checksum = "a8805b6ad230dbfc249a4c8a2ddb8cdad1053377739b7c8a6a78f06328170b63"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -12897,13 +12912,12 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f526cb636baa1ad67f1410884e7a5580b7068beee3ee88609fb39f906bab27b3"
+checksum = "1a7892c7c442aa109053998b360e91a26d776f63cb394fa50caf59ca626c08dd"
 dependencies = [
  "anyhow",
  "bincode",
- "bindgen 0.70.1",
  "cfg-if",
  "hex",
  "num-bigint 0.4.6",
@@ -12922,9 +12936,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-machine"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228ec6719240b0933289332d730be328d3a3e4f9e6ff9ee2e20ec2b4a99aeed9"
+checksum = "2fb19db493ef086f0b5869e6c5ad52da728f265647a8a1f2bf765c3236eda6b0"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -12945,9 +12959,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d8dae789acfa3b4e8211234d05901c28cd1b988f230c9db0c29207fa131071a"
+checksum = "349ca86c7a88456c9f0fa1c8869e0d35bb63d6c811dc9ad8337c90909ce532ec"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -12974,26 +12988,15 @@ dependencies = [
  "rustls 0.23.37",
  "serde",
  "sha2 0.10.9",
- "slop-algebra",
- "slop-alloc",
- "slop-basefold",
- "slop-commit",
- "slop-jagged",
- "slop-merkle-tree",
- "slop-multilinear",
- "slop-stacked",
- "slop-sumcheck",
- "slop-tensor",
  "sp1-build",
  "sp1-core-executor",
+ "sp1-core-executor-runner",
  "sp1-core-machine",
- "sp1-cuda",
  "sp1-hypercube",
  "sp1-primitives",
  "sp1-prover",
  "sp1-prover-types",
  "sp1-recursion-executor",
- "sp1-recursion-gnark-ffi",
  "sp1-verifier",
  "strum 0.27.2",
  "tempfile",
@@ -13016,9 +13019,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11dd15bf0dc2325ced1f3bb58bfed84efc5228a09127ab6787ee5103514f09e"
+checksum = "f97f6c90e5f44ffaa18e0cf7aab2f4f02d0a2261aee21d4a48e09cc453ef0e0e"
 dependencies = [
  "bincode",
  "blake3",
@@ -13043,9 +13046,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45aa8c53b0332dcce1f588185df97e8ed9e7a6b37b0c6584f29674017628831f"
+checksum = "d31a7c3f072f248342284031684c9195e2264422964129c3b8652f9196ecc937"
 dependencies = [
  "cfg-if",
  "critical-section",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,56 +22,56 @@ publish = false
 rust-version = "1.93"
 
 [workspace.dependencies]
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f", features = [
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f", features = [
   "evm",
 ] }
-sov-accounts = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-api-spec = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-attester-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-chain-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-bank = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-blob-storage = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-paymaster = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-capabilities = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-cli = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-hyperlane-integration = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f", features = [
+sov-accounts = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-api-spec = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-attester-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-chain-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-bank = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-blob-storage = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-paymaster = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-capabilities = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-cli = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-hyperlane-integration = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f", features = [
   "evm",
 ] }
-sov-eth-client = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-test-state-consistency = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-ledger-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-modules-rollup-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-uniqueness = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-operator-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-prover-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-revenue-share = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-sequencer = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-sequencer-registry = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-soak-testing-lib = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-stf-runner = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-test-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-rollup-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-universal-wallet = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-zkvm-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-build = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-ethereum = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-evm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-soak-testing = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-eip712-auth = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-rest-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-proxy-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f", features = ["native"] }
+sov-eth-client = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-test-state-consistency = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-ledger-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-modules-rollup-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-uniqueness = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-operator-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-prover-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-revenue-share = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-sequencer = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-sequencer-registry = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-soak-testing-lib = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-stf-runner = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-test-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-rollup-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-universal-wallet = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-zkvm-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-build = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-ethereum = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-evm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-soak-testing = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-eip712-auth = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-rest-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-proxy-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f", features = ["native"] }
 
 
 stf-starter = { path = "./crates/stf", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,56 +22,56 @@ publish = false
 rust-version = "1.93"
 
 [workspace.dependencies]
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f", features = [
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4", features = [
   "evm",
 ] }
-sov-accounts = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-api-spec = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-attester-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-chain-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-bank = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-blob-storage = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-paymaster = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-capabilities = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-cli = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-hyperlane-integration = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f", features = [
+sov-accounts = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-api-spec = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-attester-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-chain-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-bank = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-blob-storage = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-paymaster = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-capabilities = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-cli = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-hyperlane-integration = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4", features = [
   "evm",
 ] }
-sov-eth-client = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-test-state-consistency = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-ledger-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-modules-rollup-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-uniqueness = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-operator-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-prover-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-revenue-share = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-sequencer = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-sequencer-registry = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-soak-testing-lib = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-stf-runner = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-test-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-rollup-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-universal-wallet = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-zkvm-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-build = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-ethereum = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-evm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-soak-testing = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-eip712-auth = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-rest-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-proxy-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f", features = ["native"] }
+sov-eth-client = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-test-state-consistency = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-ledger-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-modules-rollup-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-uniqueness = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-operator-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-prover-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-revenue-share = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-sequencer = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-sequencer-registry = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-soak-testing-lib = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-stf-runner = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-test-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-rollup-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-universal-wallet = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-zkvm-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-build = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-ethereum = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-evm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-soak-testing = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-eip712-auth = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-rest-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-proxy-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4", features = ["native"] }
 
 
 stf-starter = { path = "./crates/stf", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ install-risc0-toolchain: ## Install correct version of RISC0 toolchain
 
 install-sp1-toolchain: ## Install correct version of SP1 toolchain
 	curl -L https://sp1up.succinct.xyz | bash
-	~/.sp1/bin/sp1up $${GITHUB_TOKEN:+--token "$$GITHUB_TOKEN"} --version 6.0.2
+	~/.sp1/bin/sp1up $${GITHUB_TOKEN:+--token "$$GITHUB_TOKEN"} --version 6.1.0
 	~/.sp1/bin/cargo-prove prove --version
 	~/.sp1/bin/cargo-prove prove install-toolchain
 	@echo "SP1 toolchain version:"

--- a/crates/provers/risc0/guest-celestia/Cargo.lock
+++ b/crates/provers/risc0/guest-celestia/Cargo.lock
@@ -1016,9 +1016,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-proto"
-version = "0.12.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65013505b04171f213d833b92bb076e9f229c36e5d144cb2faf25378397e2597"
+checksum = "8fba8cece7d46d57382503455ed2847aef638dd99d6ecc96c72f61680e571c6b"
 dependencies = [
  "bytes",
  "prost",
@@ -1032,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.20.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe616393f4c88756ed6b8097167a623c6e4e48e2a3d75109e3ea5d5941587e0"
+checksum = "394ae3bd14f0a3792c312fd0ffc1a1719fd3c8d28cf1f8016afd01cce6197001"
 dependencies = [
  "base64",
  "bech32",
@@ -2271,9 +2271,9 @@ dependencies = [
 
 [[package]]
 name = "lumina-utils"
-version = "0.5.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e68ba51207213b3fa8a42465526efdbe6c3c983a78a2a972d3a8e94d2bf9ab8"
+checksum = "e13be66015388d059c1c9f95de2508329c4a9ed6e563b7a3423fcd92ffbba3bf"
 dependencies = [
  "js-sys",
 ]
@@ -2401,7 +2401,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 
 [[package]]
 name = "nmt-rs"
@@ -4018,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4050,7 +4050,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4070,7 +4070,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4089,7 +4089,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4109,7 +4109,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4121,7 +4121,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4167,7 +4167,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4183,7 +4183,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "borsh",
  "derivative",
@@ -4217,7 +4217,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4235,7 +4235,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4271,7 +4271,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4292,7 +4292,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -4305,7 +4305,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4319,7 +4319,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4337,7 +4337,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4367,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4389,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4407,7 +4407,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4425,7 +4425,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4444,7 +4444,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4463,7 +4463,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4478,7 +4478,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4503,7 +4503,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4523,7 +4523,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4539,7 +4539,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4561,7 +4561,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4576,7 +4576,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4589,7 +4589,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4611,7 +4611,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "bech32",
  "borsh",
@@ -4628,7 +4628,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -4638,7 +4638,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "convert_case",

--- a/crates/provers/risc0/guest-celestia/Cargo.lock
+++ b/crates/provers/risc0/guest-celestia/Cargo.lock
@@ -2401,7 +2401,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 
 [[package]]
 name = "nmt-rs"
@@ -4018,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4050,7 +4050,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4070,7 +4070,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4089,7 +4089,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4109,7 +4109,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4121,7 +4121,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4167,7 +4167,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4183,7 +4183,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "borsh",
  "derivative",
@@ -4217,7 +4217,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4235,7 +4235,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4271,7 +4271,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4292,7 +4292,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -4305,7 +4305,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4319,7 +4319,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4337,7 +4337,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4367,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4389,7 +4389,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4407,7 +4407,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4425,7 +4425,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4444,7 +4444,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4463,7 +4463,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4478,7 +4478,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4503,7 +4503,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4523,7 +4523,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4539,7 +4539,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4561,7 +4561,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4576,7 +4576,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4589,7 +4589,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4611,7 +4611,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "bech32",
  "borsh",
@@ -4628,7 +4628,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -4638,7 +4638,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "convert_case",

--- a/crates/provers/risc0/guest-celestia/Cargo.toml
+++ b/crates/provers/risc0/guest-celestia/Cargo.toml
@@ -12,16 +12,16 @@ anyhow = { version = "1.0.95" }
 risc0-zkvm = { version = "3.0", default-features = false, features = ["std"] }
 risc0-zkvm-platform = { version = "2.2" }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["celestia_da"] }
 

--- a/crates/provers/risc0/guest-celestia/Cargo.toml
+++ b/crates/provers/risc0/guest-celestia/Cargo.toml
@@ -12,16 +12,16 @@ anyhow = { version = "1.0.95" }
 risc0-zkvm = { version = "3.0", default-features = false, features = ["std"] }
 risc0-zkvm-platform = { version = "2.2" }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["celestia_da"] }
 

--- a/crates/provers/risc0/guest-mock/Cargo.lock
+++ b/crates/provers/risc0/guest-mock/Cargo.lock
@@ -1016,9 +1016,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-proto"
-version = "0.12.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65013505b04171f213d833b92bb076e9f229c36e5d144cb2faf25378397e2597"
+checksum = "8fba8cece7d46d57382503455ed2847aef638dd99d6ecc96c72f61680e571c6b"
 dependencies = [
  "bytes",
  "prost",
@@ -1032,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.20.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe616393f4c88756ed6b8097167a623c6e4e48e2a3d75109e3ea5d5941587e0"
+checksum = "394ae3bd14f0a3792c312fd0ffc1a1719fd3c8d28cf1f8016afd01cce6197001"
 dependencies = [
  "base64",
  "bech32",
@@ -2420,9 +2420,9 @@ dependencies = [
 
 [[package]]
 name = "lumina-utils"
-version = "0.5.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e68ba51207213b3fa8a42465526efdbe6c3c983a78a2a972d3a8e94d2bf9ab8"
+checksum = "e13be66015388d059c1c9f95de2508329c4a9ed6e563b7a3423fcd92ffbba3bf"
 dependencies = [
  "js-sys",
 ]
@@ -2550,7 +2550,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 
 [[package]]
 name = "nmt-rs"
@@ -4182,7 +4182,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4196,7 +4196,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4214,7 +4214,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4234,7 +4234,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4253,7 +4253,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4273,7 +4273,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4285,7 +4285,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -4305,7 +4305,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4331,7 +4331,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4347,7 +4347,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "borsh",
  "derivative",
@@ -4361,7 +4361,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4379,7 +4379,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4415,7 +4415,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4436,7 +4436,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -4449,7 +4449,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4463,7 +4463,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4483,7 +4483,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4501,7 +4501,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4531,7 +4531,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4553,7 +4553,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4571,7 +4571,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4589,7 +4589,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4608,7 +4608,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4627,7 +4627,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4642,7 +4642,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4667,7 +4667,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4687,7 +4687,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4703,7 +4703,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4725,7 +4725,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4740,7 +4740,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4753,7 +4753,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4775,7 +4775,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "bech32",
  "borsh",
@@ -4792,7 +4792,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -4802,7 +4802,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "convert_case",

--- a/crates/provers/risc0/guest-mock/Cargo.lock
+++ b/crates/provers/risc0/guest-mock/Cargo.lock
@@ -2550,7 +2550,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 
 [[package]]
 name = "nmt-rs"
@@ -4182,7 +4182,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4196,7 +4196,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4214,7 +4214,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4234,7 +4234,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4253,7 +4253,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4273,7 +4273,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4285,7 +4285,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -4305,7 +4305,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4331,7 +4331,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4347,7 +4347,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "borsh",
  "derivative",
@@ -4361,7 +4361,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4379,7 +4379,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4415,7 +4415,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4436,7 +4436,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -4449,7 +4449,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4463,7 +4463,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4483,7 +4483,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4501,7 +4501,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4531,7 +4531,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4553,7 +4553,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4571,7 +4571,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4589,7 +4589,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4608,7 +4608,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4627,7 +4627,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4642,7 +4642,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4667,7 +4667,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4687,7 +4687,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4703,7 +4703,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4725,7 +4725,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4740,7 +4740,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4753,7 +4753,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4775,7 +4775,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "bech32",
  "borsh",
@@ -4792,7 +4792,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -4802,7 +4802,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "convert_case",

--- a/crates/provers/risc0/guest-mock/Cargo.toml
+++ b/crates/provers/risc0/guest-mock/Cargo.toml
@@ -15,16 +15,16 @@ risc0-zkvm-platform = { version = "2.2" }
 serde = { version = "1.0.188", features = ["derive", "rc"] }
 
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f", optional = true }
 
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["mock_da"] }

--- a/crates/provers/risc0/guest-mock/Cargo.toml
+++ b/crates/provers/risc0/guest-mock/Cargo.toml
@@ -15,16 +15,16 @@ risc0-zkvm-platform = { version = "2.2" }
 serde = { version = "1.0.188", features = ["derive", "rc"] }
 
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4", optional = true }
 
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["mock_da"] }

--- a/crates/provers/sp1/Cargo.toml
+++ b/crates/provers/sp1/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 lazy_static = { workspace = true }
 
 [build-dependencies]
-sp1-build = { version = "6.0.2", default-features = false }
+sp1-build = { version = "6.1.0", default-features = false }
 sov-zkvm-utils = { workspace = true }
 
 

--- a/crates/provers/sp1/guest-celestia/Cargo.lock
+++ b/crates/provers/sp1/guest-celestia/Cargo.lock
@@ -1249,9 +1249,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-proto"
-version = "0.12.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65013505b04171f213d833b92bb076e9f229c36e5d144cb2faf25378397e2597"
+checksum = "8fba8cece7d46d57382503455ed2847aef638dd99d6ecc96c72f61680e571c6b"
 dependencies = [
  "bytes",
  "prost",
@@ -1265,9 +1265,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.20.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe616393f4c88756ed6b8097167a623c6e4e48e2a3d75109e3ea5d5941587e0"
+checksum = "394ae3bd14f0a3792c312fd0ffc1a1719fd3c8d28cf1f8016afd01cce6197001"
 dependencies = [
  "base64 0.22.1",
  "bech32",
@@ -3390,9 +3390,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lumina-utils"
-version = "0.5.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e68ba51207213b3fa8a42465526efdbe6c3c983a78a2a972d3a8e94d2bf9ab8"
+checksum = "e13be66015388d059c1c9f95de2508329c4a9ed6e563b7a3423fcd92ffbba3bf"
 dependencies = [
  "js-sys",
 ]
@@ -3575,7 +3575,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 
 [[package]]
 name = "nmt-rs"
@@ -6278,7 +6278,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6292,7 +6292,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6310,7 +6310,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6330,7 +6330,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6349,7 +6349,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6369,7 +6369,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6381,7 +6381,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -6401,7 +6401,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6427,7 +6427,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6443,7 +6443,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "borsh",
  "derivative",
@@ -6476,7 +6476,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6494,7 +6494,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6530,7 +6530,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6551,7 +6551,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -6564,7 +6564,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6577,7 +6577,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6595,7 +6595,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6625,7 +6625,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6647,7 +6647,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6665,7 +6665,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6683,7 +6683,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6702,7 +6702,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6721,7 +6721,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6736,7 +6736,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6756,7 +6756,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6772,7 +6772,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6792,7 +6792,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6814,7 +6814,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6829,7 +6829,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6842,7 +6842,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -6864,7 +6864,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "bech32",
  "borsh",
@@ -6881,7 +6881,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -6891,7 +6891,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/sp1/guest-celestia/Cargo.lock
+++ b/crates/provers/sp1/guest-celestia/Cargo.lock
@@ -207,7 +207,7 @@ dependencies = [
  "rand 0.9.2",
  "rapidhash",
  "ruint",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "serde",
  "sha3",
 ]
@@ -949,26 +949,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1296,15 +1276,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1338,17 +1309,6 @@ dependencies = [
  "multibase",
  "multihash",
  "unsigned-varint",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -1506,6 +1466,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crash-context"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031ed29858d90cfdf27fe49fae28028a1f20466db97962fa2f4ea34809aeebf3"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "mach2",
+]
+
+[[package]]
+name = "crash-handler"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0df5c9639f4942eb7702b964b3f9adf03a55724a57558cc177407388a8b936e2"
+dependencies = [
+ "cfg-if",
+ "crash-context",
+ "libc",
+ "mach2",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1838,7 +1822,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2017,20 +2001,6 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
-
-[[package]]
-name = "downloader"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac1e888d6830712d565b2f3a974be3200be9296bc1b03db8251a4cbf18a4a34"
-dependencies = [
- "digest 0.10.7",
- "futures",
- "rand 0.8.5",
- "reqwest",
- "thiserror 1.0.69",
- "tokio",
-]
 
 [[package]]
 name = "dunce"
@@ -3282,16 +3252,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
-
-[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3395,6 +3355,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13be66015388d059c1c9f95de2508329c4a9ed6e563b7a3423fcd92ffbba3bf"
 dependencies = [
  "js-sys",
+]
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3575,7 +3544,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 
 [[package]]
 name = "nmt-rs"
@@ -4606,7 +4575,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "socket2 0.6.3",
  "thiserror 2.0.18",
@@ -4626,7 +4595,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -5229,12 +5198,6 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -5802,18 +5765,18 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-air"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "242539aba9e5424923d7bd629775570c7d10ec28584e96ea599575a51bedcde8"
+checksum = "9bfd4c0fb41e0638afd60ce2ebf74d59225e3c20e25b8f202912c8a38f793de4"
 dependencies = [
  "p3-air",
 ]
 
 [[package]]
 name = "slop-algebra"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "691beea96fd18d4881f9ca1cb4e58194dac6366f24956a2fdae00c8ee382a0c9"
+checksum = "733912d564a68ff209707e71fdc517d4ff82d4362b6a409f6a8241dfcb7a576a"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -5822,9 +5785,9 @@ dependencies = [
 
 [[package]]
 name = "slop-alloc"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b7800cba9b31377f9353174d13fd8e39608b6f1d1531f0e92b8ce4af49ae0"
+checksum = "0ee6cc091290f9db6e3d3452430970f5234dbd270541300c9554d8172e18d0c2"
 dependencies = [
  "serde",
  "slop-algebra",
@@ -5833,9 +5796,9 @@ dependencies = [
 
 [[package]]
 name = "slop-baby-bear"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949e3c822532a87b4ad04f7280283c256621b0a83aee1b40cbd721df29df641d"
+checksum = "3f0138bae78c3d8f1691ee28315dd87b3d71c0b71e51e7b9eabf8d2e6ffffcfa"
 dependencies = [
  "lazy_static",
  "p3-baby-bear",
@@ -5848,9 +5811,9 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58984f92091a668a006b6895487079d99209e599b02d636f061fe4ae26977fb5"
+checksum = "272d5e3082f066bcdd6ded60e3dd403a7697f4bbfaeea4c4e00f088bd555305e"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -5871,9 +5834,9 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold-prover"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86eb8581b52f97860242fe5e8d6b49d2a37e1b38d4a647adf24acaa2965ee7d"
+checksum = "175433ed8fc9a45fcb835b4375bbe54c5df0022b920f248055da6ae99e141104"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -5898,9 +5861,9 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1852499c245f7f3dec23408b4930b3ea7570ae914b9c31f12950ac539d85ee"
+checksum = "a71b23ede427299e139fb822c5d0ea8fb931dc297eba0c6e2f30f774c04ebc81"
 dependencies = [
  "ff 0.13.1",
  "p3-bn254-fr",
@@ -5914,9 +5877,9 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4349af93602f3876a3eda948a74d9d16d774c401dfe25f41a45ffd84f230bc1"
+checksum = "59e4993210936ab317c0d56ee8257e1cdfe6c2fae4df1e158737f034e21d45f9"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -5927,9 +5890,9 @@ dependencies = [
 
 [[package]]
 name = "slop-commit"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584339690d20fb6b34b0dc957cbd267221ba2ab7b0c1292c118378f3498979c4"
+checksum = "afe1a49612ffedb6a44825ccbaa54ea53670a61366b8112a80865fef462630f9"
 dependencies = [
  "p3-commit",
  "serde",
@@ -5938,9 +5901,9 @@ dependencies = [
 
 [[package]]
 name = "slop-dft"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "148281e1611ca570d016a733aac2f3ec9867241cc800a96d15bc6ecfd010daf7"
+checksum = "b1fe8ca56f2cb47f22658f923e8d1a97413bb89ecc4e7185722ec406e61b82e9"
 dependencies = [
  "p3-dft",
  "serde",
@@ -5952,18 +5915,18 @@ dependencies = [
 
 [[package]]
 name = "slop-fri"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0857a346ea28496ee56b1dcad192db8c7ff0455a18bfd67ce6513323b594b746"
+checksum = "434a8e3f5fc6c5a1973a3c3964b4589af26c74bd480fd7cd6dcb0feb7d7e8f92"
 dependencies = [
  "p3-fri",
 ]
 
 [[package]]
 name = "slop-futures"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bbfea5447d243572da7aae8d5e57856229a97fb8bc6a42439d4c5f4de951ee0"
+checksum = "69e76ea10d2865798d6a9c39faffbc2c23c0bbf34a6e449e83de409aa265171a"
 dependencies = [
  "crossbeam",
  "futures",
@@ -5976,9 +5939,9 @@ dependencies = [
 
 [[package]]
 name = "slop-jagged"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc420430b93d38e9aae903bc4bc11c342f8d49d015cca26eeb36a6ea3f7a0f1f"
+checksum = "8677ede7f5b5f1fa19884ba07b6120cbb74b4e4ff4cb56cd068e01fffd4e603b"
 dependencies = [
  "derive-where",
  "futures",
@@ -6010,18 +5973,18 @@ dependencies = [
 
 [[package]]
 name = "slop-keccak-air"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "288abf40d9901f79e221ece87f11324826289bf5d694fde07dd785bdb4afda38"
+checksum = "794162816eb0c8869f2bf09881ac6a7c808da1aab11e097ca25460e4ef895cc7"
 dependencies = [
  "p3-keccak-air",
 ]
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "574784c044d11cf9d8238dc18bce9b897bc34d0fb1daaceafd75ebb400084016"
+checksum = "8986e94b9a43d58fc8ce5bf111b0985479ab888ced923e3052fb19943f7859b4"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -6034,27 +5997,27 @@ dependencies = [
 
 [[package]]
 name = "slop-matrix"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd1117c395388bd172826115ac4f9a7e09bf9c937ceafa82194132a058e27c0d"
+checksum = "a89bef0d6e09bc5431c6b50b3eee460722ca9eb569dffcdec582bd1d72db496c"
 dependencies = [
  "p3-matrix",
 ]
 
 [[package]]
 name = "slop-maybe-rayon"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81316cfe721c3f47cd0af63002a8b6557c951ff9588fa7db0f4f3b99af091486"
+checksum = "e135011bcdae048b9e85f42ba95cc8dc69cb4f5566289044cabe67a6ac65e6e0"
 dependencies = [
  "p3-maybe-rayon",
 ]
 
 [[package]]
 name = "slop-merkle-tree"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e700652778c15320f6269362103b87a3787a7c9d70fb05d9742dbce66c46f764"
+checksum = "748e3fb2d76fd2e2017d9e544072a8318efc1deac6277b5721d31381a674d505"
 dependencies = [
  "derive-where",
  "ff 0.13.1",
@@ -6073,15 +6036,16 @@ dependencies = [
  "slop-poseidon2",
  "slop-symmetric",
  "slop-tensor",
+ "slop-utils",
  "thiserror 1.0.69",
  "zkhash",
 ]
 
 [[package]]
 name = "slop-multilinear"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6151db452ace0d960314f46c61a2b8d45e1fa4dfd5830447c67fc1e1e1e823b5"
+checksum = "b579ce845ca26e0c2750d11f09327add269e4b695c21b35f1659f49b9bd08311"
 dependencies = [
  "derive-where",
  "futures",
@@ -6100,27 +6064,27 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5af617970b63e8d7199204bc02996745b6c35c39f2b513a118c62c7b1a0b2f1b"
+checksum = "5b06e4a24cba104a0a39740eedd97e60e8896926cc38e6a58d5866cc9811affa"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58d82c53508f3ebff8acdabb5db2584f37686257a2549a17c977cf30cd9e24e6"
+checksum = "0b0b66701c82f6aab97f4990b5d9ed7463beb5b5042dbe5eda5f6c71a6207b35"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-stacked"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a25c9fb9c908a2d10037934e2c299d30f98a2146f6ded87a7b529b05ddbfda27"
+checksum = "8992c338b13abe792faf62000a47096f08817ea655036c530990b1c60c5ff256"
 dependencies = [
  "derive-where",
  "futures",
@@ -6141,9 +6105,9 @@ dependencies = [
 
 [[package]]
 name = "slop-sumcheck"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c691f34c05e933777059a10804e00f77834b927abc2701f5f394e9c2b49c1c"
+checksum = "45fdcab8b7e0fa43b808112fd1c387eabfa7e09435c6a4fb92e45b917971ade8"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -6159,18 +6123,18 @@ dependencies = [
 
 [[package]]
 name = "slop-symmetric"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15acfa7f567ffa4f36de134492632a397c33fa6af2e48894e50978b52eeeb871"
+checksum = "e6d159948b924fd00f280064d7a049e43dceb2f26067f32fb99570d3169969ee"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "slop-tensor"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1796e5ff7dcdcd2c15f423a27550a4688e25009bd5ca648d9593d66f243950d6"
+checksum = "f0a6b65130a06d1b1a24ab4928e1eadc5a6e14f35c171c0e69d5b9cf6c4d56e9"
 dependencies = [
  "arrayvec",
  "derive-where",
@@ -6188,18 +6152,18 @@ dependencies = [
 
 [[package]]
 name = "slop-uni-stark"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504f32330985e48a6aa9c9e0985641a4dc084d3843ff59075591b24b818f2a67"
+checksum = "b3655347bb0dc0e559a63fa8c5053a79d9d0258af04b6b3bebfc51fff880416a"
 dependencies = [
  "p3-uni-stark",
 ]
 
 [[package]]
 name = "slop-utils"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba510663661800990c1207ddbf3a1e67a551f05d882a60197adbb19c6824754f"
+checksum = "4fad36458e05b6ccc8ebe951734e9d036128eb0f01596824e1104a37b3216654"
 dependencies = [
  "p3-util",
  "tracing-forest",
@@ -6208,9 +6172,9 @@ dependencies = [
 
 [[package]]
 name = "slop-whir"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71f6a16450fc701450831121810da91c6ee3ac50e4705327dcd4957b046015a"
+checksum = "d104106013cf050132b47d73568b4562e273c0dda3a1d304a96afab25737d414"
 dependencies = [
  "derive-where",
  "futures",
@@ -6278,7 +6242,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6292,7 +6256,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6310,7 +6274,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6330,7 +6294,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6349,7 +6313,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6369,7 +6333,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6381,7 +6345,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -6401,7 +6365,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6427,7 +6391,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6443,7 +6407,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "borsh",
  "derivative",
@@ -6476,7 +6440,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6494,7 +6458,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6530,7 +6494,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6551,7 +6515,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -6564,7 +6528,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6577,7 +6541,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6595,7 +6559,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6625,7 +6589,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6647,7 +6611,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6665,7 +6629,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6683,7 +6647,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6702,7 +6666,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6721,7 +6685,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6736,7 +6700,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6756,7 +6720,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6772,7 +6736,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6792,7 +6756,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6814,7 +6778,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6829,7 +6793,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6842,7 +6806,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -6864,7 +6828,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "bech32",
  "borsh",
@@ -6881,7 +6845,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -6891,7 +6855,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -6899,9 +6863,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38fe5854ea3054c20b34fe85b08437583174e8cd71e612fcfef67ea841daea14"
+checksum = "7321136acefff985b0fb201b84359d609451bbd0a63203d4b601eaabe28da14f"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -6913,9 +6877,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc9268de48a534ccb82287a517c0a07ee594136bc9fce6c7eb438c69e7917be"
+checksum = "89e911afd7e96cab3936e275445e23d1e6cb26776bd06223cb4466e812b13b54"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -6952,10 +6916,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp1-core-machine"
-version = "6.0.2"
+name = "sp1-core-executor-runner"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d436300d3052341854e58c88a9b5444a6f45689ee8933f9bec047ac367693182"
+checksum = "b3bf24cda2b466c097e62a60a3e1ac7ff014d7972f4ff350d72ff2b89eff5128"
+dependencies = [
+ "base64 0.22.1",
+ "bincode",
+ "cargo_metadata",
+ "hashbrown 0.14.5",
+ "hex",
+ "libc",
+ "sha2 0.10.9",
+ "sp1-core-executor",
+ "sp1-core-executor-runner-binary",
+ "sp1-jit",
+ "sp1-primitives",
+ "sysinfo",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "sp1-core-executor-runner-binary"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf22b7b1696ce686f79efb99a543a10b0b82d1068834087d21f0fe3d76d9054d"
+dependencies = [
+ "bincode",
+ "crash-handler",
+ "libc",
+ "serde",
+ "sp1-core-executor",
+ "sp1-jit",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
+name = "sp1-core-machine"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fd9328937306a831184febaae80c7b63ee15d3716573f0a34d62f5dee7408d"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -6981,6 +6982,7 @@ dependencies = [
  "slop-uni-stark",
  "snowbridge-amcl",
  "sp1-core-executor",
+ "sp1-core-executor-runner",
  "sp1-curves",
  "sp1-derive",
  "sp1-hypercube",
@@ -6999,31 +7001,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp1-cuda"
-version = "6.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a03bb846daaabe6e94af5e5199aa110b42c68482d6380b7e765d9d6b65119d52"
-dependencies = [
- "bincode",
- "bytes",
- "reqwest",
- "serde",
- "serde_json",
- "sp1-core-executor",
- "sp1-core-machine",
- "sp1-primitives",
- "sp1-prover",
- "sp1-prover-types",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "sp1-curves"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e3ad4fc0f5ea7286fbe5c788d97125dc0cb40eb81f15becb432a65f350cd2f9"
+checksum = "bf1e420a0980906ff8f875525664209395c7a5243243ff70283adb357e921ef2"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -7042,9 +7023,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f111a90749619066fbd7ba102b22375bc6c824abb66804c3184ba0f650d017a2"
+checksum = "caa1235972b67b86514c3f23ba690972b712dd009159c2e50f723d7ac02173d8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7053,9 +7034,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-hypercube"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caff340db83b2c38b01f022624b8b792c38f201417581d6855dbe9a445d2485f"
+checksum = "b8314d1620d659913912121a3ecae19d1384fdd06e43d954034cad8bd082f5db"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -7101,12 +7082,13 @@ dependencies = [
 
 [[package]]
 name = "sp1-jit"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcadaa9206d36ae953c1b4390373879281ef1423115aa180e7ef0e82259d92aa"
+checksum = "7e6b9a7102c21e5ecd5b65861188f068f17951a2db9bc3fd4f65cd5f9b0e8449"
 dependencies = [
  "dynasmrt",
  "hashbrown 0.14.5",
+ "libc",
  "memfd",
  "memmap2",
  "serde",
@@ -7116,9 +7098,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517e820776910468611149dda66791bdb700c1b7d68b96f0ea2e604f00ad8771"
+checksum = "9b96392c1b1c197beaa6b0806099a8d73643a09d5ac0874e26c9c5153a7fcb4c"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -7128,9 +7110,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f395525b4fc46d37136f45be264c81718a67f4409c14c547ff491a263e019e7"
+checksum = "b6b77098dae9d62e080be3af253188c08e7e96e666423306654eede0110bf363"
 dependencies = [
  "bincode",
  "blake3",
@@ -7152,15 +7134,14 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64545387a6b5ee58155d75183223a8f19961e23d76a13a49c16514896e52ff7"
+checksum = "d4ba1691f53df50f8024f756c3a0e7b009e544e31c7297ae591eceba1d27232c"
 dependencies = [
  "anyhow",
  "bincode",
  "clap",
  "dirs",
- "downloader",
  "either",
  "enum-map",
  "eyre",
@@ -7191,6 +7172,7 @@ dependencies = [
  "slop-stacked",
  "slop-symmetric",
  "sp1-core-executor",
+ "sp1-core-executor-runner",
  "sp1-core-machine",
  "sp1-derive",
  "sp1-hypercube",
@@ -7216,9 +7198,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover-types"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "834512266314b8dd35fd52b921d62abb113c3c35b27358acdbc178b3a17ec72e"
+checksum = "011fe0b63d8b930665e5e6ca5f9f766c1b442727ec473d0baeea629d225c4360"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -7237,9 +7219,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "105531a782d66030eab608832e0829e4699053a6d41cd3c2c7931def9c9540fb"
+checksum = "ae1bb2594e6480d20c6d4be6099408df3a0de85bc956f0e74511c80515ac9e2d"
 dependencies = [
  "bincode",
  "itertools 0.14.0",
@@ -7277,9 +7259,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ab98d241444285539b0d4203288fbe9887707c355e346cfb176b461524c58d"
+checksum = "8e113c225149badeda05e679f169281cad6ef0480919f726e21acdfbf38848fb"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -7298,9 +7280,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-executor"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc69767dce218874edbef09515ccc5fb32d5e6b857a95a99944a66f6f405f5b1"
+checksum = "a8805b6ad230dbfc249a4c8a2ddb8cdad1053377739b7c8a6a78f06328170b63"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -7322,13 +7304,12 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f526cb636baa1ad67f1410884e7a5580b7068beee3ee88609fb39f906bab27b3"
+checksum = "1a7892c7c442aa109053998b360e91a26d776f63cb394fa50caf59ca626c08dd"
 dependencies = [
  "anyhow",
  "bincode",
- "bindgen",
  "cfg-if",
  "hex",
  "num-bigint 0.4.6",
@@ -7347,9 +7328,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-machine"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228ec6719240b0933289332d730be328d3a3e4f9e6ff9ee2e20ec2b4a99aeed9"
+checksum = "2fb19db493ef086f0b5869e6c5ad52da728f265647a8a1f2bf765c3236eda6b0"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -7370,9 +7351,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d8dae789acfa3b4e8211234d05901c28cd1b988f230c9db0c29207fa131071a"
+checksum = "349ca86c7a88456c9f0fa1c8869e0d35bb63d6c811dc9ad8337c90909ce532ec"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7388,26 +7369,15 @@ dependencies = [
  "num-bigint 0.4.6",
  "serde",
  "sha2 0.10.9",
- "slop-algebra",
- "slop-alloc",
- "slop-basefold",
- "slop-commit",
- "slop-jagged",
- "slop-merkle-tree",
- "slop-multilinear",
- "slop-stacked",
- "slop-sumcheck",
- "slop-tensor",
  "sp1-build",
  "sp1-core-executor",
+ "sp1-core-executor-runner",
  "sp1-core-machine",
- "sp1-cuda",
  "sp1-hypercube",
  "sp1-primitives",
  "sp1-prover",
  "sp1-prover-types",
  "sp1-recursion-executor",
- "sp1-recursion-gnark-ffi",
  "sp1-verifier",
  "strum 0.27.2",
  "tempfile",
@@ -7418,9 +7388,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11dd15bf0dc2325ced1f3bb58bfed84efc5228a09127ab6787ee5103514f09e"
+checksum = "f97f6c90e5f44ffaa18e0cf7aab2f4f02d0a2261aee21d4a48e09cc453ef0e0e"
 dependencies = [
  "bincode",
  "blake3",
@@ -7445,9 +7415,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45aa8c53b0332dcce1f588185df97e8ed9e7a6b37b0c6584f29674017628831f"
+checksum = "d31a7c3f072f248342284031684c9195e2264422964129c3b8652f9196ecc937"
 dependencies = [
  "cfg-if",
  "critical-section",

--- a/crates/provers/sp1/guest-celestia/Cargo.toml
+++ b/crates/provers/sp1/guest-celestia/Cargo.toml
@@ -12,16 +12,16 @@ anyhow = { version = "1.0.95" }
 sp1-zkvm = { version = "6.0.2" }
 stf-starter = { path = "../../../stf", default-features = false, features = ["celestia_da"] }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f", optional = true }
 
 [patch.crates-io]
 sha2-v0-9-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.9.9-sp1-6.0.0" }

--- a/crates/provers/sp1/guest-celestia/Cargo.toml
+++ b/crates/provers/sp1/guest-celestia/Cargo.toml
@@ -9,19 +9,19 @@ resolver = "2"
 [dependencies]
 anyhow = { version = "1.0.95" }
 
-sp1-zkvm = { version = "6.0.2" }
+sp1-zkvm = { version = "6.1.0" }
 stf-starter = { path = "../../../stf", default-features = false, features = ["celestia_da"] }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4", optional = true }
 
 [patch.crates-io]
 sha2-v0-9-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.9.9-sp1-6.0.0" }

--- a/crates/provers/sp1/guest-mock/Cargo.lock
+++ b/crates/provers/sp1/guest-mock/Cargo.lock
@@ -207,7 +207,7 @@ dependencies = [
  "rand 0.9.2",
  "rapidhash",
  "ruint",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "serde",
  "sha3",
 ]
@@ -949,26 +949,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1296,15 +1276,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1338,17 +1309,6 @@ dependencies = [
  "multibase",
  "multihash",
  "unsigned-varint",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -1506,6 +1466,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crash-context"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031ed29858d90cfdf27fe49fae28028a1f20466db97962fa2f4ea34809aeebf3"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "mach2",
+]
+
+[[package]]
+name = "crash-handler"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0df5c9639f4942eb7702b964b3f9adf03a55724a57558cc177407388a8b936e2"
+dependencies = [
+ "cfg-if",
+ "crash-context",
+ "libc",
+ "mach2",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1838,7 +1822,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2017,20 +2001,6 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
-
-[[package]]
-name = "downloader"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac1e888d6830712d565b2f3a974be3200be9296bc1b03db8251a4cbf18a4a34"
-dependencies = [
- "digest 0.10.7",
- "futures",
- "rand 0.8.5",
- "reqwest",
- "thiserror 1.0.69",
- "tokio",
-]
 
 [[package]]
 name = "dunce"
@@ -3302,16 +3272,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
-
-[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3415,6 +3375,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13be66015388d059c1c9f95de2508329c4a9ed6e563b7a3423fcd92ffbba3bf"
 dependencies = [
  "js-sys",
+]
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3595,7 +3564,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 
 [[package]]
 name = "nmt-rs"
@@ -4626,7 +4595,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "socket2 0.6.3",
  "thiserror 2.0.18",
@@ -4646,7 +4615,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -5249,12 +5218,6 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -5822,18 +5785,18 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-air"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "242539aba9e5424923d7bd629775570c7d10ec28584e96ea599575a51bedcde8"
+checksum = "9bfd4c0fb41e0638afd60ce2ebf74d59225e3c20e25b8f202912c8a38f793de4"
 dependencies = [
  "p3-air",
 ]
 
 [[package]]
 name = "slop-algebra"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "691beea96fd18d4881f9ca1cb4e58194dac6366f24956a2fdae00c8ee382a0c9"
+checksum = "733912d564a68ff209707e71fdc517d4ff82d4362b6a409f6a8241dfcb7a576a"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -5842,9 +5805,9 @@ dependencies = [
 
 [[package]]
 name = "slop-alloc"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b7800cba9b31377f9353174d13fd8e39608b6f1d1531f0e92b8ce4af49ae0"
+checksum = "0ee6cc091290f9db6e3d3452430970f5234dbd270541300c9554d8172e18d0c2"
 dependencies = [
  "serde",
  "slop-algebra",
@@ -5853,9 +5816,9 @@ dependencies = [
 
 [[package]]
 name = "slop-baby-bear"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949e3c822532a87b4ad04f7280283c256621b0a83aee1b40cbd721df29df641d"
+checksum = "3f0138bae78c3d8f1691ee28315dd87b3d71c0b71e51e7b9eabf8d2e6ffffcfa"
 dependencies = [
  "lazy_static",
  "p3-baby-bear",
@@ -5868,9 +5831,9 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58984f92091a668a006b6895487079d99209e599b02d636f061fe4ae26977fb5"
+checksum = "272d5e3082f066bcdd6ded60e3dd403a7697f4bbfaeea4c4e00f088bd555305e"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -5891,9 +5854,9 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold-prover"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86eb8581b52f97860242fe5e8d6b49d2a37e1b38d4a647adf24acaa2965ee7d"
+checksum = "175433ed8fc9a45fcb835b4375bbe54c5df0022b920f248055da6ae99e141104"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -5918,9 +5881,9 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1852499c245f7f3dec23408b4930b3ea7570ae914b9c31f12950ac539d85ee"
+checksum = "a71b23ede427299e139fb822c5d0ea8fb931dc297eba0c6e2f30f774c04ebc81"
 dependencies = [
  "ff 0.13.1",
  "p3-bn254-fr",
@@ -5934,9 +5897,9 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4349af93602f3876a3eda948a74d9d16d774c401dfe25f41a45ffd84f230bc1"
+checksum = "59e4993210936ab317c0d56ee8257e1cdfe6c2fae4df1e158737f034e21d45f9"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -5947,9 +5910,9 @@ dependencies = [
 
 [[package]]
 name = "slop-commit"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584339690d20fb6b34b0dc957cbd267221ba2ab7b0c1292c118378f3498979c4"
+checksum = "afe1a49612ffedb6a44825ccbaa54ea53670a61366b8112a80865fef462630f9"
 dependencies = [
  "p3-commit",
  "serde",
@@ -5958,9 +5921,9 @@ dependencies = [
 
 [[package]]
 name = "slop-dft"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "148281e1611ca570d016a733aac2f3ec9867241cc800a96d15bc6ecfd010daf7"
+checksum = "b1fe8ca56f2cb47f22658f923e8d1a97413bb89ecc4e7185722ec406e61b82e9"
 dependencies = [
  "p3-dft",
  "serde",
@@ -5972,18 +5935,18 @@ dependencies = [
 
 [[package]]
 name = "slop-fri"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0857a346ea28496ee56b1dcad192db8c7ff0455a18bfd67ce6513323b594b746"
+checksum = "434a8e3f5fc6c5a1973a3c3964b4589af26c74bd480fd7cd6dcb0feb7d7e8f92"
 dependencies = [
  "p3-fri",
 ]
 
 [[package]]
 name = "slop-futures"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bbfea5447d243572da7aae8d5e57856229a97fb8bc6a42439d4c5f4de951ee0"
+checksum = "69e76ea10d2865798d6a9c39faffbc2c23c0bbf34a6e449e83de409aa265171a"
 dependencies = [
  "crossbeam",
  "futures",
@@ -5996,9 +5959,9 @@ dependencies = [
 
 [[package]]
 name = "slop-jagged"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc420430b93d38e9aae903bc4bc11c342f8d49d015cca26eeb36a6ea3f7a0f1f"
+checksum = "8677ede7f5b5f1fa19884ba07b6120cbb74b4e4ff4cb56cd068e01fffd4e603b"
 dependencies = [
  "derive-where",
  "futures",
@@ -6030,18 +5993,18 @@ dependencies = [
 
 [[package]]
 name = "slop-keccak-air"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "288abf40d9901f79e221ece87f11324826289bf5d694fde07dd785bdb4afda38"
+checksum = "794162816eb0c8869f2bf09881ac6a7c808da1aab11e097ca25460e4ef895cc7"
 dependencies = [
  "p3-keccak-air",
 ]
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "574784c044d11cf9d8238dc18bce9b897bc34d0fb1daaceafd75ebb400084016"
+checksum = "8986e94b9a43d58fc8ce5bf111b0985479ab888ced923e3052fb19943f7859b4"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -6054,27 +6017,27 @@ dependencies = [
 
 [[package]]
 name = "slop-matrix"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd1117c395388bd172826115ac4f9a7e09bf9c937ceafa82194132a058e27c0d"
+checksum = "a89bef0d6e09bc5431c6b50b3eee460722ca9eb569dffcdec582bd1d72db496c"
 dependencies = [
  "p3-matrix",
 ]
 
 [[package]]
 name = "slop-maybe-rayon"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81316cfe721c3f47cd0af63002a8b6557c951ff9588fa7db0f4f3b99af091486"
+checksum = "e135011bcdae048b9e85f42ba95cc8dc69cb4f5566289044cabe67a6ac65e6e0"
 dependencies = [
  "p3-maybe-rayon",
 ]
 
 [[package]]
 name = "slop-merkle-tree"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e700652778c15320f6269362103b87a3787a7c9d70fb05d9742dbce66c46f764"
+checksum = "748e3fb2d76fd2e2017d9e544072a8318efc1deac6277b5721d31381a674d505"
 dependencies = [
  "derive-where",
  "ff 0.13.1",
@@ -6093,15 +6056,16 @@ dependencies = [
  "slop-poseidon2",
  "slop-symmetric",
  "slop-tensor",
+ "slop-utils",
  "thiserror 1.0.69",
  "zkhash",
 ]
 
 [[package]]
 name = "slop-multilinear"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6151db452ace0d960314f46c61a2b8d45e1fa4dfd5830447c67fc1e1e1e823b5"
+checksum = "b579ce845ca26e0c2750d11f09327add269e4b695c21b35f1659f49b9bd08311"
 dependencies = [
  "derive-where",
  "futures",
@@ -6120,27 +6084,27 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5af617970b63e8d7199204bc02996745b6c35c39f2b513a118c62c7b1a0b2f1b"
+checksum = "5b06e4a24cba104a0a39740eedd97e60e8896926cc38e6a58d5866cc9811affa"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58d82c53508f3ebff8acdabb5db2584f37686257a2549a17c977cf30cd9e24e6"
+checksum = "0b0b66701c82f6aab97f4990b5d9ed7463beb5b5042dbe5eda5f6c71a6207b35"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-stacked"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a25c9fb9c908a2d10037934e2c299d30f98a2146f6ded87a7b529b05ddbfda27"
+checksum = "8992c338b13abe792faf62000a47096f08817ea655036c530990b1c60c5ff256"
 dependencies = [
  "derive-where",
  "futures",
@@ -6161,9 +6125,9 @@ dependencies = [
 
 [[package]]
 name = "slop-sumcheck"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c691f34c05e933777059a10804e00f77834b927abc2701f5f394e9c2b49c1c"
+checksum = "45fdcab8b7e0fa43b808112fd1c387eabfa7e09435c6a4fb92e45b917971ade8"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -6179,18 +6143,18 @@ dependencies = [
 
 [[package]]
 name = "slop-symmetric"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15acfa7f567ffa4f36de134492632a397c33fa6af2e48894e50978b52eeeb871"
+checksum = "e6d159948b924fd00f280064d7a049e43dceb2f26067f32fb99570d3169969ee"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "slop-tensor"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1796e5ff7dcdcd2c15f423a27550a4688e25009bd5ca648d9593d66f243950d6"
+checksum = "f0a6b65130a06d1b1a24ab4928e1eadc5a6e14f35c171c0e69d5b9cf6c4d56e9"
 dependencies = [
  "arrayvec",
  "derive-where",
@@ -6208,18 +6172,18 @@ dependencies = [
 
 [[package]]
 name = "slop-uni-stark"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504f32330985e48a6aa9c9e0985641a4dc084d3843ff59075591b24b818f2a67"
+checksum = "b3655347bb0dc0e559a63fa8c5053a79d9d0258af04b6b3bebfc51fff880416a"
 dependencies = [
  "p3-uni-stark",
 ]
 
 [[package]]
 name = "slop-utils"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba510663661800990c1207ddbf3a1e67a551f05d882a60197adbb19c6824754f"
+checksum = "4fad36458e05b6ccc8ebe951734e9d036128eb0f01596824e1104a37b3216654"
 dependencies = [
  "p3-util",
  "tracing-forest",
@@ -6228,9 +6192,9 @@ dependencies = [
 
 [[package]]
 name = "slop-whir"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71f6a16450fc701450831121810da91c6ee3ac50e4705327dcd4957b046015a"
+checksum = "d104106013cf050132b47d73568b4562e273c0dda3a1d304a96afab25737d414"
 dependencies = [
  "derive-where",
  "futures",
@@ -6298,7 +6262,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6312,7 +6276,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6330,7 +6294,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6350,7 +6314,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6369,7 +6333,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6389,7 +6353,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6401,7 +6365,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -6421,7 +6385,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6447,7 +6411,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6463,7 +6427,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "borsh",
  "derivative",
@@ -6477,7 +6441,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6495,7 +6459,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6531,7 +6495,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6552,7 +6516,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -6565,7 +6529,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6578,7 +6542,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6598,7 +6562,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6616,7 +6580,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6646,7 +6610,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6668,7 +6632,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6686,7 +6650,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6704,7 +6668,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6723,7 +6687,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6742,7 +6706,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6757,7 +6721,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6777,7 +6741,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6793,7 +6757,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6813,7 +6777,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6835,7 +6799,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6850,7 +6814,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6863,7 +6827,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -6885,7 +6849,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "bech32",
  "borsh",
@@ -6902,7 +6866,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -6912,7 +6876,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ee7897b766ceb8e0782bc60cf33d071ed20efde4#ee7897b766ceb8e0782bc60cf33d071ed20efde4"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -6920,9 +6884,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38fe5854ea3054c20b34fe85b08437583174e8cd71e612fcfef67ea841daea14"
+checksum = "7321136acefff985b0fb201b84359d609451bbd0a63203d4b601eaabe28da14f"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -6934,9 +6898,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc9268de48a534ccb82287a517c0a07ee594136bc9fce6c7eb438c69e7917be"
+checksum = "89e911afd7e96cab3936e275445e23d1e6cb26776bd06223cb4466e812b13b54"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -6973,10 +6937,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp1-core-machine"
-version = "6.0.2"
+name = "sp1-core-executor-runner"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d436300d3052341854e58c88a9b5444a6f45689ee8933f9bec047ac367693182"
+checksum = "b3bf24cda2b466c097e62a60a3e1ac7ff014d7972f4ff350d72ff2b89eff5128"
+dependencies = [
+ "base64 0.22.1",
+ "bincode",
+ "cargo_metadata",
+ "hashbrown 0.14.5",
+ "hex",
+ "libc",
+ "sha2 0.10.9",
+ "sp1-core-executor",
+ "sp1-core-executor-runner-binary",
+ "sp1-jit",
+ "sp1-primitives",
+ "sysinfo",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "sp1-core-executor-runner-binary"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf22b7b1696ce686f79efb99a543a10b0b82d1068834087d21f0fe3d76d9054d"
+dependencies = [
+ "bincode",
+ "crash-handler",
+ "libc",
+ "serde",
+ "sp1-core-executor",
+ "sp1-jit",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
+name = "sp1-core-machine"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fd9328937306a831184febaae80c7b63ee15d3716573f0a34d62f5dee7408d"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -7002,6 +7003,7 @@ dependencies = [
  "slop-uni-stark",
  "snowbridge-amcl",
  "sp1-core-executor",
+ "sp1-core-executor-runner",
  "sp1-curves",
  "sp1-derive",
  "sp1-hypercube",
@@ -7020,31 +7022,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp1-cuda"
-version = "6.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a03bb846daaabe6e94af5e5199aa110b42c68482d6380b7e765d9d6b65119d52"
-dependencies = [
- "bincode",
- "bytes",
- "reqwest",
- "serde",
- "serde_json",
- "sp1-core-executor",
- "sp1-core-machine",
- "sp1-primitives",
- "sp1-prover",
- "sp1-prover-types",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "sp1-curves"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e3ad4fc0f5ea7286fbe5c788d97125dc0cb40eb81f15becb432a65f350cd2f9"
+checksum = "bf1e420a0980906ff8f875525664209395c7a5243243ff70283adb357e921ef2"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -7063,9 +7044,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f111a90749619066fbd7ba102b22375bc6c824abb66804c3184ba0f650d017a2"
+checksum = "caa1235972b67b86514c3f23ba690972b712dd009159c2e50f723d7ac02173d8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7074,9 +7055,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-hypercube"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caff340db83b2c38b01f022624b8b792c38f201417581d6855dbe9a445d2485f"
+checksum = "b8314d1620d659913912121a3ecae19d1384fdd06e43d954034cad8bd082f5db"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -7122,12 +7103,13 @@ dependencies = [
 
 [[package]]
 name = "sp1-jit"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcadaa9206d36ae953c1b4390373879281ef1423115aa180e7ef0e82259d92aa"
+checksum = "7e6b9a7102c21e5ecd5b65861188f068f17951a2db9bc3fd4f65cd5f9b0e8449"
 dependencies = [
  "dynasmrt",
  "hashbrown 0.14.5",
+ "libc",
  "memfd",
  "memmap2",
  "serde",
@@ -7137,9 +7119,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517e820776910468611149dda66791bdb700c1b7d68b96f0ea2e604f00ad8771"
+checksum = "9b96392c1b1c197beaa6b0806099a8d73643a09d5ac0874e26c9c5153a7fcb4c"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -7149,9 +7131,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f395525b4fc46d37136f45be264c81718a67f4409c14c547ff491a263e019e7"
+checksum = "b6b77098dae9d62e080be3af253188c08e7e96e666423306654eede0110bf363"
 dependencies = [
  "bincode",
  "blake3",
@@ -7173,15 +7155,14 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64545387a6b5ee58155d75183223a8f19961e23d76a13a49c16514896e52ff7"
+checksum = "d4ba1691f53df50f8024f756c3a0e7b009e544e31c7297ae591eceba1d27232c"
 dependencies = [
  "anyhow",
  "bincode",
  "clap",
  "dirs",
- "downloader",
  "either",
  "enum-map",
  "eyre",
@@ -7212,6 +7193,7 @@ dependencies = [
  "slop-stacked",
  "slop-symmetric",
  "sp1-core-executor",
+ "sp1-core-executor-runner",
  "sp1-core-machine",
  "sp1-derive",
  "sp1-hypercube",
@@ -7237,9 +7219,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover-types"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "834512266314b8dd35fd52b921d62abb113c3c35b27358acdbc178b3a17ec72e"
+checksum = "011fe0b63d8b930665e5e6ca5f9f766c1b442727ec473d0baeea629d225c4360"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -7258,9 +7240,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "105531a782d66030eab608832e0829e4699053a6d41cd3c2c7931def9c9540fb"
+checksum = "ae1bb2594e6480d20c6d4be6099408df3a0de85bc956f0e74511c80515ac9e2d"
 dependencies = [
  "bincode",
  "itertools 0.14.0",
@@ -7298,9 +7280,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ab98d241444285539b0d4203288fbe9887707c355e346cfb176b461524c58d"
+checksum = "8e113c225149badeda05e679f169281cad6ef0480919f726e21acdfbf38848fb"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -7319,9 +7301,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-executor"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc69767dce218874edbef09515ccc5fb32d5e6b857a95a99944a66f6f405f5b1"
+checksum = "a8805b6ad230dbfc249a4c8a2ddb8cdad1053377739b7c8a6a78f06328170b63"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -7343,13 +7325,12 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f526cb636baa1ad67f1410884e7a5580b7068beee3ee88609fb39f906bab27b3"
+checksum = "1a7892c7c442aa109053998b360e91a26d776f63cb394fa50caf59ca626c08dd"
 dependencies = [
  "anyhow",
  "bincode",
- "bindgen",
  "cfg-if",
  "hex",
  "num-bigint 0.4.6",
@@ -7368,9 +7349,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-machine"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "228ec6719240b0933289332d730be328d3a3e4f9e6ff9ee2e20ec2b4a99aeed9"
+checksum = "2fb19db493ef086f0b5869e6c5ad52da728f265647a8a1f2bf765c3236eda6b0"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -7391,9 +7372,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d8dae789acfa3b4e8211234d05901c28cd1b988f230c9db0c29207fa131071a"
+checksum = "349ca86c7a88456c9f0fa1c8869e0d35bb63d6c811dc9ad8337c90909ce532ec"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7409,26 +7390,15 @@ dependencies = [
  "num-bigint 0.4.6",
  "serde",
  "sha2 0.10.9",
- "slop-algebra",
- "slop-alloc",
- "slop-basefold",
- "slop-commit",
- "slop-jagged",
- "slop-merkle-tree",
- "slop-multilinear",
- "slop-stacked",
- "slop-sumcheck",
- "slop-tensor",
  "sp1-build",
  "sp1-core-executor",
+ "sp1-core-executor-runner",
  "sp1-core-machine",
- "sp1-cuda",
  "sp1-hypercube",
  "sp1-primitives",
  "sp1-prover",
  "sp1-prover-types",
  "sp1-recursion-executor",
- "sp1-recursion-gnark-ffi",
  "sp1-verifier",
  "strum 0.27.2",
  "tempfile",
@@ -7439,9 +7409,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11dd15bf0dc2325ced1f3bb58bfed84efc5228a09127ab6787ee5103514f09e"
+checksum = "f97f6c90e5f44ffaa18e0cf7aab2f4f02d0a2261aee21d4a48e09cc453ef0e0e"
 dependencies = [
  "bincode",
  "blake3",
@@ -7466,9 +7436,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.0.2"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45aa8c53b0332dcce1f588185df97e8ed9e7a6b37b0c6584f29674017628831f"
+checksum = "d31a7c3f072f248342284031684c9195e2264422964129c3b8652f9196ecc937"
 dependencies = [
  "cfg-if",
  "critical-section",

--- a/crates/provers/sp1/guest-mock/Cargo.lock
+++ b/crates/provers/sp1/guest-mock/Cargo.lock
@@ -1249,9 +1249,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-proto"
-version = "0.12.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65013505b04171f213d833b92bb076e9f229c36e5d144cb2faf25378397e2597"
+checksum = "8fba8cece7d46d57382503455ed2847aef638dd99d6ecc96c72f61680e571c6b"
 dependencies = [
  "bytes",
  "prost",
@@ -1265,9 +1265,9 @@ dependencies = [
 
 [[package]]
 name = "celestia-types"
-version = "0.20.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe616393f4c88756ed6b8097167a623c6e4e48e2a3d75109e3ea5d5941587e0"
+checksum = "394ae3bd14f0a3792c312fd0ffc1a1719fd3c8d28cf1f8016afd01cce6197001"
 dependencies = [
  "base64 0.22.1",
  "bech32",
@@ -3410,9 +3410,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lumina-utils"
-version = "0.5.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e68ba51207213b3fa8a42465526efdbe6c3c983a78a2a972d3a8e94d2bf9ab8"
+checksum = "e13be66015388d059c1c9f95de2508329c4a9ed6e563b7a3423fcd92ffbba3bf"
 dependencies = [
  "js-sys",
 ]
@@ -3595,7 +3595,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 
 [[package]]
 name = "nmt-rs"
@@ -6298,7 +6298,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6312,7 +6312,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6330,7 +6330,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6350,7 +6350,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6369,7 +6369,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6389,7 +6389,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6401,7 +6401,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -6421,7 +6421,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6447,7 +6447,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6463,7 +6463,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "borsh",
  "derivative",
@@ -6477,7 +6477,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6495,7 +6495,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6531,7 +6531,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6552,7 +6552,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -6565,7 +6565,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6578,7 +6578,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6598,7 +6598,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6616,7 +6616,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6646,7 +6646,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6668,7 +6668,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6686,7 +6686,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6704,7 +6704,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6723,7 +6723,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6742,7 +6742,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6757,7 +6757,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6777,7 +6777,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6793,7 +6793,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6813,7 +6813,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6835,7 +6835,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6850,7 +6850,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6863,7 +6863,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -6885,7 +6885,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "bech32",
  "borsh",
@@ -6902,7 +6902,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -6912,7 +6912,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=ca8df23dd956d6cb327ead027cc4ac8a479a8e2f#ca8df23dd956d6cb327ead027cc4ac8a479a8e2f"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=5855b3adccac3cecea845f98137612e54fbbc47f#5855b3adccac3cecea845f98137612e54fbbc47f"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/sp1/guest-mock/Cargo.toml
+++ b/crates/provers/sp1/guest-mock/Cargo.toml
@@ -10,16 +10,16 @@ resolver = "2"
 anyhow = { version = "1.0.95" }
 sp1-zkvm = { version = "6.0.2" }
 serde = { version = "1.0.188", features = ["derive", "rc"] }
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ca8df23dd956d6cb327ead027cc4ac8a479a8e2f", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["mock_da"] }
 

--- a/crates/provers/sp1/guest-mock/Cargo.toml
+++ b/crates/provers/sp1/guest-mock/Cargo.toml
@@ -8,18 +8,18 @@ resolver = "2"
 
 [dependencies]
 anyhow = { version = "1.0.95" }
-sp1-zkvm = { version = "6.0.2" }
+sp1-zkvm = { version = "6.1.0" }
 serde = { version = "1.0.188", features = ["derive", "rc"] }
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "5855b3adccac3cecea845f98137612e54fbbc47f", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "ee7897b766ceb8e0782bc60cf33d071ed20efde4", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["mock_da"] }
 

--- a/crates/rollup/src/zkvm.rs
+++ b/crates/rollup/src/zkvm.rs
@@ -82,9 +82,9 @@ mod sp1 {
 
     pub fn create_inner_vm_from_config(
         prover_config: sov_stf_runner::processes::RollupProverConfig<Zkvm>,
-    ) -> ZkvmHost<'static> {
+    ) -> ZkvmHost {
         let (elf, _) = prover_config.split();
-        ZkvmHost::new(*elf)
+        ZkvmHost::new(*elf).expect("Failed to create SP1 host")
     }
 }
 

--- a/integrations/docker-compose.celestia.yml
+++ b/integrations/docker-compose.celestia.yml
@@ -1,6 +1,6 @@
 services:
   celestia-validator:
-    image: ghcr.io/sovereign-labs/celestia-validator-devnet:v7.0.2-mocha
+    image: ghcr.io/sovereign-labs/celestia-validator-devnet:v8.0.1-mocha
     hostname: validator
     environment:
       NO_COLOR: 1
@@ -15,7 +15,7 @@ services:
       - genesis:/genesis
 
   celestia-node-0:
-    image: ghcr.io/sovereign-labs/celestia-bridge-devnet:v0.29.1-mocha
+    image: ghcr.io/sovereign-labs/celestia-bridge-devnet:v0.30.1-mocha
     hostname: sequencer-0
     depends_on:
       - celestia-validator


### PR DESCRIPTION
Upgrading to latest dev on 2026-04-14 ee7897b766ceb8e0782bc60cf33d071ed20efde4

Breaking changes resolved:
- SP1Host no longer has a lifetime parameter and `SP1Host::new` now returns `anyhow::Result<Self>`. Updated `create_inner_vm_from_config` in `crates/rollup/src/zkvm.rs` accordingly.
- Bumped Celestia docker images for Celestia v8 support: validator v7.0.2-mocha -> v8.0.1-mocha and bridge v0.29.1-mocha -> v0.30.1-mocha in `integrations/docker-compose.celestia.yml`.
- Bumped sp1 version
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/rollup-starter/pull/162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
