### PR TITLE
Update to the latest dev 2026-04-20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6607,7 +6607,7 @@ dependencies = [
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 
 [[package]]
 name = "nix"
@@ -11049,7 +11049,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11064,7 +11064,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -11085,7 +11085,7 @@ dependencies = [
 [[package]]
 name = "sov-api-spec"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "backon",
@@ -11109,7 +11109,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11130,7 +11130,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11151,7 +11151,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-sender"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11174,7 +11174,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11194,7 +11194,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11206,7 +11206,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -11226,7 +11226,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11261,7 +11261,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11277,7 +11277,7 @@ dependencies = [
 [[package]]
 name = "sov-cli"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11300,7 +11300,7 @@ dependencies = [
 [[package]]
 name = "sov-db"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11336,7 +11336,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -11355,7 +11355,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11373,7 +11373,7 @@ dependencies = [
 [[package]]
 name = "sov-eth-client"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -11401,7 +11401,7 @@ dependencies = [
 [[package]]
 name = "sov-eth-dev-signer"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11412,7 +11412,7 @@ dependencies = [
 [[package]]
 name = "sov-ethereum"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11443,7 +11443,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11485,7 +11485,7 @@ dependencies = [
 [[package]]
 name = "sov-evm-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -11501,7 +11501,7 @@ dependencies = [
 [[package]]
 name = "sov-full-node-configs"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "schemars 0.8.22",
@@ -11515,7 +11515,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11539,7 +11539,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -11553,7 +11553,7 @@ dependencies = [
 [[package]]
 name = "sov-ledger-apis"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11578,7 +11578,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bincode",
@@ -11601,7 +11601,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11635,7 +11635,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11656,7 +11656,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11703,7 +11703,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bech32",
@@ -11725,7 +11725,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-rollup-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11765,7 +11765,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11786,7 +11786,7 @@ dependencies = [
 [[package]]
 name = "sov-node-client"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11805,7 +11805,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11823,7 +11823,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11845,7 +11845,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11864,7 +11864,7 @@ dependencies = [
 [[package]]
 name = "sov-proxy-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11881,7 +11881,7 @@ dependencies = [
 [[package]]
 name = "sov-rest-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11905,7 +11905,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11920,7 +11920,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11950,7 +11950,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-apis"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "axum 0.8.8",
  "base64 0.22.1",
@@ -11978,7 +11978,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-full-node-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "derive_more 2.1.1",
  "rockbound",
@@ -11990,7 +11990,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -12035,7 +12035,7 @@ dependencies = [
 [[package]]
 name = "sov-rpc-eth-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12057,7 +12057,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12108,7 +12108,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -12141,7 +12141,7 @@ dependencies = [
 [[package]]
 name = "sov-soak-testing-lib"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12163,7 +12163,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -12176,19 +12176,23 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "sha2 0.10.9",
+ "slop-algebra",
  "sov-metrics",
  "sov-rollup-interface",
  "sov-universal-wallet",
  "sov-zkvm-utils",
  "sp1-lib",
+ "sp1-primitives",
+ "sp1-recursion-executor",
  "sp1-sdk",
+ "sp1-verifier",
  "sp1-zkvm",
 ]
 
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -12217,7 +12221,7 @@ dependencies = [
 [[package]]
 name = "sov-stf-runner"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12252,7 +12256,7 @@ dependencies = [
 [[package]]
 name = "sov-synthetic-load"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12270,7 +12274,7 @@ dependencies = [
 [[package]]
 name = "sov-test-modules"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12289,7 +12293,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12304,7 +12308,7 @@ dependencies = [
 [[package]]
 name = "sov-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12365,7 +12369,7 @@ dependencies = [
 [[package]]
 name = "sov-transaction-generator"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12399,7 +12403,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12412,7 +12416,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -12434,7 +12438,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "bech32",
  "borsh",
@@ -12451,7 +12455,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -12461,7 +12465,7 @@ dependencies = [
 [[package]]
 name = "sov-value-setter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12487,7 +12491,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,57 +22,57 @@ publish = false
 rust-version = "1.93"
 
 [workspace.dependencies]
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343", features = [
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd", features = [
   "evm",
 ] }
-sov-accounts = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-api-spec = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-attester-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-chain-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-bank = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-blob-storage = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-paymaster = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-capabilities = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-cli = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-hyperlane-integration = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343", features = [
+sov-accounts = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-api-spec = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-attester-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-chain-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-bank = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-blob-storage = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-paymaster = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-capabilities = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-cli = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-hyperlane-integration = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd", features = [
   "evm",
 ] }
-sov-eth-client = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-test-state-consistency = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-ledger-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-modules-rollup-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-uniqueness = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-operator-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-prover-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-revenue-share = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-rollup-full-node-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-sequencer = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-sequencer-registry = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-soak-testing-lib = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-stf-runner = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-test-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-rollup-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-universal-wallet = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-zkvm-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-build = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-ethereum = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-evm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-soak-testing = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-eip712-auth = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-rest-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-proxy-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343", features = ["native"] }
+sov-eth-client = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-test-state-consistency = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-ledger-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-modules-rollup-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-uniqueness = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-operator-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-prover-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-revenue-share = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-rollup-full-node-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-sequencer = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-sequencer-registry = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-soak-testing-lib = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-stf-runner = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-test-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-rollup-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-universal-wallet = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-zkvm-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-build = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-ethereum = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-evm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-soak-testing = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-eip712-auth = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-rest-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-proxy-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd", features = ["native"] }
 
 
 stf-starter = { path = "./crates/stf", default-features = false }

--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ $ cargo run --no-default-features --features celestia_da,risc0
 
 Proving is disabled by default. Enable it with this environment variable before recompiling the rollup:
 
+- `export SOV_PROVER_MODE=disable` - Skip verification logic (the same as not set)
 - `export SOV_PROVER_MODE=prove` - Run verifier and create a SNARK proof
 
 ### Paymaster Configuration

--- a/README.md
+++ b/README.md
@@ -233,11 +233,8 @@ $ cargo run --no-default-features --features celestia_da,risc0
 
 ### Enabling the Prover
 
-Proving is disabled by default. Enable it with these environment variables before recompiling the rollup:
+Proving is disabled by default. Enable it with this environment variable before recompiling the rollup:
 
-- `export SOV_PROVER_MODE=skip` - Skip verification logic
-- `export SOV_PROVER_MODE=simulate` - Run verification logic in the current process
-- `export SOV_PROVER_MODE=execute` - Run verifier in a zkVM executor
 - `export SOV_PROVER_MODE=prove` - Run verifier and create a SNARK proof
 
 ### Paymaster Configuration

--- a/crates/provers/risc0/guest-celestia/Cargo.lock
+++ b/crates/provers/risc0/guest-celestia/Cargo.lock
@@ -2401,7 +2401,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 
 [[package]]
 name = "nmt-rs"
@@ -4018,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4050,7 +4050,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4070,7 +4070,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4089,7 +4089,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4109,7 +4109,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4121,7 +4121,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4168,7 +4168,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4184,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "borsh",
  "derivative",
@@ -4219,7 +4219,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4237,7 +4237,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4273,7 +4273,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4294,7 +4294,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -4307,7 +4307,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4321,7 +4321,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4340,7 +4340,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4370,7 +4370,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4392,7 +4392,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4410,7 +4410,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4428,7 +4428,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4447,7 +4447,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4466,7 +4466,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4481,7 +4481,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4507,7 +4507,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4527,7 +4527,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4543,7 +4543,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4566,7 +4566,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4581,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4594,7 +4594,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4616,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "bech32",
  "borsh",
@@ -4633,7 +4633,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -4643,7 +4643,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "convert_case",

--- a/crates/provers/risc0/guest-celestia/Cargo.toml
+++ b/crates/provers/risc0/guest-celestia/Cargo.toml
@@ -12,16 +12,16 @@ anyhow = { version = "1.0.95" }
 risc0-zkvm = { version = "3.0", default-features = false, features = ["std"] }
 risc0-zkvm-platform = { version = "2.2" }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["celestia_da"] }
 

--- a/crates/provers/risc0/guest-mock/Cargo.lock
+++ b/crates/provers/risc0/guest-mock/Cargo.lock
@@ -2550,7 +2550,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 
 [[package]]
 name = "nmt-rs"
@@ -4182,7 +4182,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4196,7 +4196,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4214,7 +4214,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4234,7 +4234,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4253,7 +4253,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4273,7 +4273,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4285,7 +4285,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -4305,7 +4305,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4332,7 +4332,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4348,7 +4348,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "borsh",
  "derivative",
@@ -4363,7 +4363,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4381,7 +4381,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4417,7 +4417,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4438,7 +4438,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -4451,7 +4451,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4465,7 +4465,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4486,7 +4486,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4505,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4535,7 +4535,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4557,7 +4557,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4575,7 +4575,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4593,7 +4593,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4612,7 +4612,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4631,7 +4631,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4646,7 +4646,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4672,7 +4672,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4692,7 +4692,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4708,7 +4708,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4731,7 +4731,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4746,7 +4746,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4759,7 +4759,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4781,7 +4781,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "bech32",
  "borsh",
@@ -4798,7 +4798,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -4808,7 +4808,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "convert_case",

--- a/crates/provers/risc0/guest-mock/Cargo.toml
+++ b/crates/provers/risc0/guest-mock/Cargo.toml
@@ -15,16 +15,16 @@ risc0-zkvm-platform = { version = "2.2" }
 serde = { version = "1.0.188", features = ["derive", "rc"] }
 
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd", optional = true }
 
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["mock_da"] }

--- a/crates/provers/sp1/guest-celestia/Cargo.lock
+++ b/crates/provers/sp1/guest-celestia/Cargo.lock
@@ -3544,7 +3544,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 
 [[package]]
 name = "nmt-rs"
@@ -6242,7 +6242,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6256,7 +6256,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6274,7 +6274,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6294,7 +6294,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6313,7 +6313,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6333,7 +6333,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6345,7 +6345,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -6365,7 +6365,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6392,7 +6392,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6408,7 +6408,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "borsh",
  "derivative",
@@ -6442,7 +6442,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6460,7 +6460,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6496,7 +6496,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6517,7 +6517,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -6530,7 +6530,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6543,7 +6543,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6562,7 +6562,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6592,7 +6592,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6614,7 +6614,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6632,7 +6632,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6650,7 +6650,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6669,7 +6669,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6688,7 +6688,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6703,7 +6703,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6723,7 +6723,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6739,7 +6739,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6749,18 +6749,22 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "sha2 0.10.9",
+ "slop-algebra",
  "sov-rollup-interface",
  "sov-universal-wallet",
  "sov-zkvm-utils",
  "sp1-lib",
+ "sp1-primitives",
+ "sp1-recursion-executor",
  "sp1-sdk",
+ "sp1-verifier",
  "sp1-zkvm",
 ]
 
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6783,7 +6787,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6798,7 +6802,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6811,7 +6815,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -6833,7 +6837,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "bech32",
  "borsh",
@@ -6850,7 +6854,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -6860,7 +6864,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/sp1/guest-celestia/Cargo.toml
+++ b/crates/provers/sp1/guest-celestia/Cargo.toml
@@ -12,16 +12,16 @@ anyhow = { version = "1.0.95" }
 sp1-zkvm = { version = "6.1.0" }
 stf-starter = { path = "../../../stf", default-features = false, features = ["celestia_da"] }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd", optional = true }
 
 [patch.crates-io]
 sha2-v0-9-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.9.9-sp1-6.0.0" }

--- a/crates/provers/sp1/guest-mock/Cargo.lock
+++ b/crates/provers/sp1/guest-mock/Cargo.lock
@@ -3564,7 +3564,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 
 [[package]]
 name = "nmt-rs"
@@ -6262,7 +6262,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6276,7 +6276,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6294,7 +6294,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6314,7 +6314,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6333,7 +6333,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6353,7 +6353,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6365,7 +6365,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -6385,7 +6385,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6412,7 +6412,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6428,7 +6428,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "borsh",
  "derivative",
@@ -6443,7 +6443,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6461,7 +6461,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6497,7 +6497,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6518,7 +6518,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -6531,7 +6531,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6544,7 +6544,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6565,7 +6565,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6584,7 +6584,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6614,7 +6614,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6636,7 +6636,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6654,7 +6654,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6672,7 +6672,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6691,7 +6691,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6710,7 +6710,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6725,7 +6725,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6745,7 +6745,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6761,7 +6761,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6771,18 +6771,22 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "sha2 0.10.9",
+ "slop-algebra",
  "sov-rollup-interface",
  "sov-universal-wallet",
  "sov-zkvm-utils",
  "sp1-lib",
+ "sp1-primitives",
+ "sp1-recursion-executor",
  "sp1-sdk",
+ "sp1-verifier",
  "sp1-zkvm",
 ]
 
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6805,7 +6809,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6820,7 +6824,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6833,7 +6837,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -6855,7 +6859,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "bech32",
  "borsh",
@@ -6872,7 +6876,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -6882,7 +6886,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e279f2f3a09a3553ec8b91fe0fecd74ad33c5343#e279f2f3a09a3553ec8b91fe0fecd74ad33c5343"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=86b5162738ebc9d838b8eff087d76b8b1d8afbcd#86b5162738ebc9d838b8eff087d76b8b1d8afbcd"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/sp1/guest-mock/Cargo.toml
+++ b/crates/provers/sp1/guest-mock/Cargo.toml
@@ -10,16 +10,16 @@ resolver = "2"
 anyhow = { version = "1.0.95" }
 sp1-zkvm = { version = "6.1.0" }
 serde = { version = "1.0.188", features = ["derive", "rc"] }
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e279f2f3a09a3553ec8b91fe0fecd74ad33c5343", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "86b5162738ebc9d838b8eff087d76b8b1d8afbcd", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["mock_da"] }
 

--- a/crates/rollup/src/bin/rollup.rs
+++ b/crates/rollup/src/bin/rollup.rs
@@ -4,12 +4,11 @@ use anyhow::Context;
 use clap::Parser;
 use rollup_starter::da::DaService;
 use rollup_starter::rollup::StarterRollup;
-use rollup_starter::zkvm::{rollup_host_args, InnerZkvm};
 use sov_modules_rollup_blueprint::logging::initialize_logging;
 use sov_modules_rollup_blueprint::FullNodeBlueprint;
 use sov_modules_rollup_blueprint::Rollup;
 use sov_rollup_interface::execution_mode::Native;
-use sov_stf_runner::processes::{RollupProverConfig, RollupProverConfigDiscriminants};
+use sov_stf_runner::processes::RollupProverConfig;
 use sov_stf_runner::{from_toml_path, RollupConfig};
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -109,14 +108,9 @@ async fn main() {
     prometheus_exporter::start(address.parse().unwrap())
         .expect("Could not start prometheus server");
 
-    let prover_config_disc = parse_prover_config().expect("Malformed prover_config");
-    tracing::info!(
-        ?prover_config_disc,
-        "Running demo rollup with prover config"
-    );
+    let prover_config = parse_prover_config().expect("Malformed prover_config");
+    tracing::info!(?prover_config, "Running demo rollup with prover config");
 
-    let prover_config =
-        prover_config_disc.map(|config_disc| config_disc.into_config(rollup_host_args()));
     let rollup = new_rollup(
         args.genesis_path,
         args.rollup_config_path,
@@ -129,10 +123,10 @@ async fn main() {
     rollup.run().await.expect("Couldn't run rollup");
 }
 
-fn parse_prover_config() -> anyhow::Result<Option<RollupProverConfigDiscriminants>> {
+fn parse_prover_config() -> anyhow::Result<RollupProverConfig> {
     if let Some(value) = option_env!("SOV_PROVER_MODE") {
         tracing::warn!("SOV_PROVER_MODE is set to {}, but proving is not currently supported. Ignoring prover config.", value);
-        Ok(None)
+        Ok(RollupProverConfig::Disabled)
         // TODO: Re-enable proving once https://github.com/Sovereign-Labs/sovereign-sdk-wip/issues/2814 is resolved
         //
         // let config = std::str::FromStr::from_str(value).inspect_err(|&error| {
@@ -140,20 +134,20 @@ fn parse_prover_config() -> anyhow::Result<Option<RollupProverConfigDiscriminant
         // })?;
         // #[cfg(debug_assertions)]
         // {
-        //     if config == RollupProverConfigDiscriminants::Prove {
+        //     if config == RollupProverConfig::Prove {
         //         tracing::warn!(prover_config = ?config, "Given RollupProverConfig might cause slow rollup progression if not compiled in release mode.");
         //     }
         // }
-        // Ok(Some(config))
+        // Ok(config)
     } else {
-        Ok(None)
+        Ok(RollupProverConfig::Disabled)
     }
 }
 
 async fn new_rollup(
     genesis_path: PathBuf,
     rollup_config_path: PathBuf,
-    prover_config: Option<RollupProverConfig<InnerZkvm>>,
+    prover_config: RollupProverConfig,
     start_at_rollup_height: Option<RollupHeight>,
     stop_at_rollup_height: Option<RollupHeight>,
 ) -> Result<Rollup<StarterRollup<Native>, Native>, anyhow::Error> {

--- a/crates/rollup/src/rollup.rs
+++ b/crates/rollup/src/rollup.rs
@@ -40,7 +40,7 @@ use stf_starter::Runtime;
 use tokio::sync::watch;
 
 use crate::da::{new_da_service, new_verifier, DaService, DaSpec};
-use crate::zkvm::{create_inner_vm_from_config, get_outer_vm, Hasher, InnerZkvm, OuterZkvm};
+use crate::zkvm::{create_inner_vm, get_outer_vm, Hasher, InnerZkvm, OuterZkvm};
 
 type NativeStorage = NomtProverStorage<
     DefaultStorageSpec<Hasher>,
@@ -129,12 +129,11 @@ impl FullNodeBlueprint<Native> for StarterRollup<Native> {
 
     async fn create_prover_service(
         &self,
-        prover_config: RollupProverConfig<<Self::Spec as Spec>::InnerZkvm>,
+        _prover_config: RollupProverConfig,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         _da_service: &Self::DaService,
     ) -> Self::ProverService {
-        let inner_vm = create_inner_vm_from_config(prover_config.clone());
-        let (_, prover_config_disc) = prover_config.split();
+        let inner_vm = create_inner_vm();
         let outer_vm = get_outer_vm();
         let da_verifier = new_verifier();
 
@@ -142,7 +141,6 @@ impl FullNodeBlueprint<Native> for StarterRollup<Native> {
             inner_vm,
             outer_vm,
             da_verifier,
-            prover_config_disc,
             rollup_config.proof_manager.prover_address,
         )
     }

--- a/crates/rollup/src/zkvm.rs
+++ b/crates/rollup/src/zkvm.rs
@@ -39,10 +39,8 @@ mod risc0 {
         )
     }
 
-    pub fn create_inner_vm_from_config(
-        prover_config: sov_stf_runner::processes::RollupProverConfig<Zkvm>,
-    ) -> ZkvmHost<'static> {
-        let (elf, _) = prover_config.split();
+    pub fn create_inner_vm() -> ZkvmHost<'static> {
+        let elf = rollup_host_args();
         ZkvmHost::new(*elf)
     }
 }
@@ -80,10 +78,8 @@ mod sp1 {
         }
     }
 
-    pub fn create_inner_vm_from_config(
-        prover_config: sov_stf_runner::processes::RollupProverConfig<Zkvm>,
-    ) -> ZkvmHost {
-        let (elf, _) = prover_config.split();
+    pub fn create_inner_vm() -> ZkvmHost {
+        let elf = rollup_host_args();
         ZkvmHost::new(*elf).expect("Failed to create SP1 host")
     }
 }
@@ -99,10 +95,7 @@ mod mock_zkvm {
         Arc::new(())
     }
 
-    pub fn create_inner_vm_from_config(
-        _prover_config: sov_stf_runner::processes::RollupProverConfig<Zkvm>,
-    ) -> ZkvmHost {
-        // Mock zkvm doesn't need the ELF from prover config
+    pub fn create_inner_vm() -> ZkvmHost {
         ZkvmHost::new()
     }
 
@@ -111,20 +104,17 @@ mod mock_zkvm {
 
 #[cfg(feature = "mock_zkvm")]
 pub use mock_zkvm::{
-    create_inner_vm_from_config, rollup_host_args, Hasher, Zkvm as InnerZkvm,
-    ZkvmHost as InnerZkvmHost,
+    create_inner_vm, rollup_host_args, Hasher, Zkvm as InnerZkvm, ZkvmHost as InnerZkvmHost,
 };
 
 #[cfg(feature = "risc0")]
 pub use risc0::{
-    create_inner_vm_from_config, rollup_host_args, Hasher, Zkvm as InnerZkvm,
-    ZkvmHost as InnerZkvmHost,
+    create_inner_vm, rollup_host_args, Hasher, Zkvm as InnerZkvm, ZkvmHost as InnerZkvmHost,
 };
 
 #[cfg(feature = "sp1")]
 pub use sp1::{
-    create_inner_vm_from_config, rollup_host_args, Hasher, Zkvm as InnerZkvm,
-    ZkvmHost as InnerZkvmHost,
+    create_inner_vm, rollup_host_args, Hasher, Zkvm as InnerZkvm, ZkvmHost as InnerZkvmHost,
 };
 
 pub use sov_mock_zkvm::MockZkvm as OuterZkvm;

--- a/crates/rollup/tests/bank/mod.rs
+++ b/crates/rollup/tests/bank/mod.rs
@@ -56,7 +56,7 @@ async fn bank_tx_tests() -> Result<(), anyhow::Error> {
             rest_port_tx,
             std::path::PathBuf::from_str("../../configs/mock/genesis.json")
                 .expect("Failed to build genesis config path"),
-            None,
+            sov_stf_runner::processes::RollupProverConfig::Disabled,
             MockDaConfig {
                 connection_string: MockDaConfig::sqlite_in_memory(),
                 sender_address: MockAddress::new([0; 32]),

--- a/crates/rollup/tests/test_helpers.rs
+++ b/crates/rollup/tests/test_helpers.rs
@@ -4,7 +4,6 @@ use std::num::{NonZero, NonZeroU64, NonZeroUsize};
 use std::path::Path;
 
 use rollup_starter::rollup::StarterRollup;
-use rollup_starter::zkvm::InnerZkvm;
 use sov_address::EthereumAddress;
 use sov_db::config::RollupDbConfig;
 use sov_mock_da::MockDaConfig;
@@ -25,7 +24,7 @@ const PROVER_ADDRESS: &str = "0x4fD62a0D0c35e1Fdcd97231A4586E65e7Eb454a5";
 pub async fn start_rollup(
     rest_reporting_channel: oneshot::Sender<SocketAddr>,
     genesis_input: std::path::PathBuf,
-    rollup_prover_config: Option<RollupProverConfig<InnerZkvm>>,
+    rollup_prover_config: RollupProverConfig,
     da_config: MockDaConfig,
 ) {
     let temp_dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Upgrading to latest dev on 2026-04-20 86b5162738ebc9d838b8eff087d76b8b1d8afbcd

Breaking changes resolved:
- RollupProverConfig refactored from Option<RollupProverConfig<Zkvm>> to a plain enum (Prove | Disabled) (sovereign-sdk #2761 + #2752). Removed the Skip variant, RollupProverConfigDiscriminants, .split() helper and the prover_config_disc argument to ParallelProverService::new_with_default_workers.
- crates/rollup/src/zkvm.rs: replaced create_inner_vm_from_config with create_inner_vm that reads the ELF via rollup_host_args() directly.
- crates/rollup/src/rollup.rs, bin/rollup.rs, tests/test_helpers.rs, tests/bank/mod.rs: adapted signatures to the non-Option, non-generic RollupProverConfig and drop the fifth argument from new_with_default_workers.
- README.md: replaced the SOV_PROVER_MODE skip/simulate/execute options with the sole remaining "prove" mode.