### PR TITLE
Update to the latest dev 2026-04-24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6607,7 +6607,7 @@ dependencies = [
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 
 [[package]]
 name = "nix"
@@ -11049,7 +11049,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11064,7 +11064,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -11085,7 +11085,7 @@ dependencies = [
 [[package]]
 name = "sov-api-spec"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "backon",
@@ -11109,7 +11109,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11130,7 +11130,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11151,7 +11151,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-sender"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11174,7 +11174,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11194,7 +11194,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11206,7 +11206,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -11226,7 +11226,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11261,7 +11261,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11277,7 +11277,7 @@ dependencies = [
 [[package]]
 name = "sov-cli"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11300,7 +11300,7 @@ dependencies = [
 [[package]]
 name = "sov-db"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11336,7 +11336,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -11355,7 +11355,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11373,7 +11373,7 @@ dependencies = [
 [[package]]
 name = "sov-eth-client"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -11401,7 +11401,7 @@ dependencies = [
 [[package]]
 name = "sov-eth-dev-signer"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11412,7 +11412,7 @@ dependencies = [
 [[package]]
 name = "sov-ethereum"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11443,7 +11443,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11485,7 +11485,7 @@ dependencies = [
 [[package]]
 name = "sov-evm-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -11501,7 +11501,7 @@ dependencies = [
 [[package]]
 name = "sov-full-node-configs"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "schemars 0.8.22",
@@ -11515,7 +11515,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11539,7 +11539,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -11553,7 +11553,7 @@ dependencies = [
 [[package]]
 name = "sov-ledger-apis"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11578,7 +11578,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bincode",
@@ -11601,7 +11601,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11635,7 +11635,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11656,7 +11656,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11703,7 +11703,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bech32",
@@ -11725,7 +11725,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-rollup-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11765,7 +11765,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11786,7 +11786,7 @@ dependencies = [
 [[package]]
 name = "sov-node-client"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11805,7 +11805,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11823,7 +11823,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11845,7 +11845,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11864,7 +11864,7 @@ dependencies = [
 [[package]]
 name = "sov-proxy-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11881,7 +11881,7 @@ dependencies = [
 [[package]]
 name = "sov-rest-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11905,7 +11905,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11920,7 +11920,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11950,7 +11950,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-apis"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "axum 0.8.8",
  "base64 0.22.1",
@@ -11978,7 +11978,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-full-node-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "derive_more 2.1.1",
  "rockbound",
@@ -11990,7 +11990,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -12035,7 +12035,7 @@ dependencies = [
 [[package]]
 name = "sov-rpc-eth-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12057,7 +12057,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12108,7 +12108,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -12141,7 +12141,7 @@ dependencies = [
 [[package]]
 name = "sov-soak-testing-lib"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12163,7 +12163,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -12192,7 +12192,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -12221,7 +12221,7 @@ dependencies = [
 [[package]]
 name = "sov-stf-runner"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12256,7 +12256,7 @@ dependencies = [
 [[package]]
 name = "sov-synthetic-load"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12274,7 +12274,7 @@ dependencies = [
 [[package]]
 name = "sov-test-modules"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12293,7 +12293,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12308,7 +12308,7 @@ dependencies = [
 [[package]]
 name = "sov-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12369,7 +12369,7 @@ dependencies = [
 [[package]]
 name = "sov-transaction-generator"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12403,7 +12403,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12416,7 +12416,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -12438,7 +12438,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "bech32",
  "borsh",
@@ -12455,7 +12455,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -12465,7 +12465,7 @@ dependencies = [
 [[package]]
 name = "sov-value-setter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12491,7 +12491,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,57 +22,57 @@ publish = false
 rust-version = "1.93"
 
 [workspace.dependencies]
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779", features = [
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce", features = [
   "evm",
 ] }
-sov-accounts = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-api-spec = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-attester-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-chain-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-bank = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-blob-storage = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-paymaster = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-capabilities = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-cli = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-hyperlane-integration = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779", features = [
+sov-accounts = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-api-spec = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-attester-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-chain-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-bank = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-blob-storage = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-paymaster = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-capabilities = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-cli = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-hyperlane-integration = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce", features = [
   "evm",
 ] }
-sov-eth-client = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-test-state-consistency = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-ledger-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-modules-rollup-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-uniqueness = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-operator-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-prover-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-revenue-share = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-rollup-full-node-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-sequencer = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-sequencer-registry = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-soak-testing-lib = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-stf-runner = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-test-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-rollup-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-universal-wallet = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-zkvm-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-build = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-ethereum = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-evm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-soak-testing = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-eip712-auth = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-rest-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-proxy-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779", features = ["native"] }
+sov-eth-client = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-test-state-consistency = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-ledger-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-modules-rollup-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-uniqueness = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-operator-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-prover-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-revenue-share = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-rollup-full-node-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-sequencer = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-sequencer-registry = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-soak-testing-lib = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-stf-runner = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-test-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-rollup-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-universal-wallet = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-zkvm-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-build = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-ethereum = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-evm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-soak-testing = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-eip712-auth = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-rest-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-proxy-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce", features = ["native"] }
 
 
 stf-starter = { path = "./crates/stf", default-features = false }

--- a/crates/provers/risc0/guest-celestia/Cargo.lock
+++ b/crates/provers/risc0/guest-celestia/Cargo.lock
@@ -2401,7 +2401,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 
 [[package]]
 name = "nmt-rs"
@@ -4018,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4050,7 +4050,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4070,7 +4070,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4089,7 +4089,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4109,7 +4109,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4121,7 +4121,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4168,7 +4168,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4184,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "borsh",
  "derivative",
@@ -4219,7 +4219,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4237,7 +4237,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4273,7 +4273,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4294,7 +4294,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -4307,7 +4307,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4321,7 +4321,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4340,7 +4340,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4370,7 +4370,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4392,7 +4392,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4410,7 +4410,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4428,7 +4428,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4447,7 +4447,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4466,7 +4466,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4481,7 +4481,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4507,7 +4507,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4527,7 +4527,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4543,7 +4543,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4566,7 +4566,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4581,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4594,7 +4594,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4616,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "bech32",
  "borsh",
@@ -4633,7 +4633,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -4643,7 +4643,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "convert_case",

--- a/crates/provers/risc0/guest-celestia/Cargo.toml
+++ b/crates/provers/risc0/guest-celestia/Cargo.toml
@@ -12,16 +12,16 @@ anyhow = { version = "1.0.95" }
 risc0-zkvm = { version = "3.0", default-features = false, features = ["std"] }
 risc0-zkvm-platform = { version = "2.2" }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["celestia_da"] }
 

--- a/crates/provers/risc0/guest-mock/Cargo.lock
+++ b/crates/provers/risc0/guest-mock/Cargo.lock
@@ -2550,7 +2550,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 
 [[package]]
 name = "nmt-rs"
@@ -4182,7 +4182,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4196,7 +4196,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4214,7 +4214,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4234,7 +4234,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4253,7 +4253,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4273,7 +4273,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4285,7 +4285,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -4305,7 +4305,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4332,7 +4332,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4348,7 +4348,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "borsh",
  "derivative",
@@ -4363,7 +4363,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4381,7 +4381,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4417,7 +4417,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4438,7 +4438,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -4451,7 +4451,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4465,7 +4465,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4486,7 +4486,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4505,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4535,7 +4535,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4557,7 +4557,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4575,7 +4575,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4593,7 +4593,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4612,7 +4612,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4631,7 +4631,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4646,7 +4646,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4672,7 +4672,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4692,7 +4692,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4708,7 +4708,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4731,7 +4731,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4746,7 +4746,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4759,7 +4759,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4781,7 +4781,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "bech32",
  "borsh",
@@ -4798,7 +4798,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -4808,7 +4808,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "convert_case",

--- a/crates/provers/risc0/guest-mock/Cargo.toml
+++ b/crates/provers/risc0/guest-mock/Cargo.toml
@@ -15,16 +15,16 @@ risc0-zkvm-platform = { version = "2.2" }
 serde = { version = "1.0.188", features = ["derive", "rc"] }
 
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce", optional = true }
 
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["mock_da"] }

--- a/crates/provers/sp1/guest-celestia/Cargo.lock
+++ b/crates/provers/sp1/guest-celestia/Cargo.lock
@@ -3544,7 +3544,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 
 [[package]]
 name = "nmt-rs"
@@ -6242,7 +6242,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6256,7 +6256,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6274,7 +6274,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6294,7 +6294,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6313,7 +6313,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6333,7 +6333,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6345,7 +6345,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -6365,7 +6365,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6392,7 +6392,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6408,7 +6408,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "borsh",
  "derivative",
@@ -6442,7 +6442,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6460,7 +6460,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6496,7 +6496,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6517,7 +6517,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -6530,7 +6530,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6543,7 +6543,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6562,7 +6562,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6592,7 +6592,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6614,7 +6614,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6632,7 +6632,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6650,7 +6650,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6669,7 +6669,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6688,7 +6688,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6703,7 +6703,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6723,7 +6723,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6739,7 +6739,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6764,7 +6764,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6787,7 +6787,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6802,7 +6802,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6815,7 +6815,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -6837,7 +6837,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "bech32",
  "borsh",
@@ -6854,7 +6854,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -6864,7 +6864,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/sp1/guest-celestia/Cargo.toml
+++ b/crates/provers/sp1/guest-celestia/Cargo.toml
@@ -12,16 +12,16 @@ anyhow = { version = "1.0.95" }
 sp1-zkvm = { version = "6.1.0" }
 stf-starter = { path = "../../../stf", default-features = false, features = ["celestia_da"] }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce", optional = true }
 
 [patch.crates-io]
 sha2-v0-9-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.9.9-sp1-6.0.0" }

--- a/crates/provers/sp1/guest-mock/Cargo.lock
+++ b/crates/provers/sp1/guest-mock/Cargo.lock
@@ -3564,7 +3564,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 
 [[package]]
 name = "nmt-rs"
@@ -6262,7 +6262,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6276,7 +6276,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6294,7 +6294,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6314,7 +6314,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6333,7 +6333,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6353,7 +6353,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6365,7 +6365,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -6385,7 +6385,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6412,7 +6412,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6428,7 +6428,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "borsh",
  "derivative",
@@ -6443,7 +6443,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6461,7 +6461,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6497,7 +6497,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6518,7 +6518,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -6531,7 +6531,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6544,7 +6544,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6565,7 +6565,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6584,7 +6584,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6614,7 +6614,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6636,7 +6636,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6654,7 +6654,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6672,7 +6672,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6691,7 +6691,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6710,7 +6710,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6725,7 +6725,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6745,7 +6745,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6761,7 +6761,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6786,7 +6786,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6809,7 +6809,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6824,7 +6824,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6837,7 +6837,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -6859,7 +6859,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "bech32",
  "borsh",
@@ -6876,7 +6876,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -6886,7 +6886,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f89964c66bcfb6a31712e43278378b54c33d3779#f89964c66bcfb6a31712e43278378b54c33d3779"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=19a5b6a04db0b4a1d07184a187a69015861378ce#19a5b6a04db0b4a1d07184a187a69015861378ce"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/sp1/guest-mock/Cargo.toml
+++ b/crates/provers/sp1/guest-mock/Cargo.toml
@@ -10,16 +10,16 @@ resolver = "2"
 anyhow = { version = "1.0.95" }
 sp1-zkvm = { version = "6.1.0" }
 serde = { version = "1.0.188", features = ["derive", "rc"] }
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f89964c66bcfb6a31712e43278378b54c33d3779", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "19a5b6a04db0b4a1d07184a187a69015861378ce", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["mock_da"] }
 

--- a/crates/rollup/src/rollup.rs
+++ b/crates/rollup/src/rollup.rs
@@ -11,11 +11,10 @@ use sov_db::ledger_db::LedgerDb;
 use sov_db::storage_manager::NomtStorageManager;
 use sov_eip712_auth::Eip712AuthenticatorTrait;
 use sov_hyperlane_integration::HyperlaneAddress;
-use sov_mock_zkvm::MockCodeCommitment;
 use sov_modules_api::capabilities::TransactionAuthenticator;
 use sov_modules_api::configurable_spec::ConfigurableSpec;
+use sov_modules_api::SequencerType;
 use sov_modules_api::{RawTx, Spec};
-use sov_modules_api::{SequencerType, ZkVerifier};
 use sov_modules_rollup_blueprint::pluggable_traits::PluggableSpec;
 use sov_modules_rollup_blueprint::proof_sender::SovApiProofSender;
 use sov_modules_rollup_blueprint::{FullNodeBlueprint, RollupBlueprint, SequencerCreationReceipt};
@@ -33,7 +32,7 @@ use sov_sequencer::{ProofBlobSender, SeqConfigExtension, Sequencer, TxStatus};
 use sov_state::nomt::prover_storage::NomtProverStorage;
 use sov_state::DefaultStorageSpec;
 use sov_state::Storage;
-use sov_stf_runner::processes::{ParallelProverService, ProverService, RollupProverConfig};
+use sov_stf_runner::processes::{ParallelProverService, RollupProverConfig};
 use sov_stf_runner::RollupConfig;
 use std::sync::Arc;
 use stf_starter::Runtime;
@@ -92,12 +91,6 @@ impl FullNodeBlueprint<Native> for StarterRollup<Native> {
 
     type ProofSender = SovApiProofSender<Self::Spec>;
 
-    fn create_outer_code_commitment(
-        &self,
-    ) -> <<Self::ProverService as ProverService>::Verifier as ZkVerifier>::CodeCommitment {
-        MockCodeCommitment::default()
-    }
-
     async fn create_endpoints(
         &self,
         state_update_receiver: StateUpdateReceiver<<Self::Spec as Spec>::Storage>,
@@ -133,7 +126,7 @@ impl FullNodeBlueprint<Native> for StarterRollup<Native> {
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
         _da_service: &Self::DaService,
     ) -> Self::ProverService {
-        let inner_vm = create_inner_vm();
+        let inner_vm = create_inner_vm().await;
         let outer_vm = get_outer_vm();
         let da_verifier = new_verifier();
 

--- a/crates/rollup/src/zkvm.rs
+++ b/crates/rollup/src/zkvm.rs
@@ -39,7 +39,7 @@ mod risc0 {
         )
     }
 
-    pub fn create_inner_vm() -> ZkvmHost<'static> {
+    pub async fn create_inner_vm() -> ZkvmHost<'static> {
         let elf = rollup_host_args();
         ZkvmHost::new(*elf)
     }
@@ -78,9 +78,21 @@ mod sp1 {
         }
     }
 
-    pub fn create_inner_vm() -> ZkvmHost {
+    pub async fn create_inner_vm() -> ZkvmHost {
         let elf = rollup_host_args();
-        ZkvmHost::new(*elf).expect("Failed to create SP1 host")
+        // The starter uses `MockZkvm` as the outer zkVM, so SP1's `outer_vk` is a
+        // placeholder derived from the inner ELF. Swap in a dedicated aggregation
+        // guest key here when wiring SP1 proof aggregation end-to-end.
+        //
+        // `ProverClient::setup` spins up its own tokio runtime, so the verifying-key
+        // derivation and the host construction must run off the async executor thread.
+        tokio::task::spawn_blocking(move || {
+            let outer_vk = Arc::new(sov_sp1_adapter::host::verifying_key_from_elf(*elf)?);
+            ZkvmHost::new(*elf, outer_vk)
+        })
+        .await
+        .expect("SP1Host setup task panicked")
+        .expect("Failed to create SP1 host")
     }
 }
 
@@ -95,7 +107,7 @@ mod mock_zkvm {
         Arc::new(())
     }
 
-    pub fn create_inner_vm() -> ZkvmHost {
+    pub async fn create_inner_vm() -> ZkvmHost {
         ZkvmHost::new()
     }
 


### PR DESCRIPTION
Upgrading to latest dev on 2026-04-24 19a5b6a04db0b4a1d07184a187a69015861378ce

Breaking changes resolved:
- `FullNodeBlueprint::create_outer_code_commitment` was removed; deleted the override in `StarterRollup` along with now-unused `MockCodeCommitment` and `ZkVerifier` imports.
- `SP1Host::new` gained a second argument `outer_vk: Arc<SP1VerifyingKey>`. The starter uses `MockZkvm` as the outer zkVM, so the SP1 host is now constructed with a placeholder key derived from the inner guest ELF via `sov_sp1_adapter::host::verifying_key_from_elf`.
- `ProofOutcome::Invalid` carries a new `Option<SerializedAggregatedProof>`; no changes needed in the starter.
- `Runtime::state_consistency` (gated by `acceptance-testing`) is pulled in through workspace feature unification from the acceptance-test crate, so `state_consistency: null` was added to `configs/mock/genesis.json` and `configs/celestia/genesis.json` to satisfy the genesis deserializer.