### PR TITLE
Update to the latest dev 2026-05-06

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1327,9 +1327,9 @@ checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.5.6"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
+checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
 dependencies = [
  "filetime",
  "futures-core",
@@ -2229,7 +2229,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -2295,9 +2295,9 @@ dependencies = [
 
 [[package]]
 name = "bollard"
-version = "0.19.4"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a52479c9237eb04047ddb94788c41ca0d26eaff8b697ecfbb4c32f7fdc3b1b"
+checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -2305,7 +2305,6 @@ dependencies = [
  "bollard-buildkit-proto",
  "bollard-stubs",
  "bytes",
- "chrono",
  "futures-core",
  "futures-util",
  "hex",
@@ -2323,14 +2322,13 @@ dependencies = [
  "rand 0.9.2",
  "rustls 0.23.37",
  "rustls-native-certs",
- "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_derive",
  "serde_json",
- "serde_repr",
  "serde_urlencoded",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -2355,19 +2353,18 @@ dependencies = [
 
 [[package]]
 name = "bollard-stubs"
-version = "1.49.1-rc.28.4.0"
+version = "1.52.1-rc.29.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5731fe885755e92beff1950774068e0cae67ea6ec7587381536fca84f1779623"
+checksum = "0f0a8ca8799131c1837d1282c3f81f31e76ceb0ce426e04a7fe1ccee3287c066"
 dependencies = [
  "base64 0.22.1",
  "bollard-buildkit-proto",
  "bytes",
- "chrono",
  "prost 0.14.3",
  "serde",
  "serde_json",
  "serde_repr",
- "serde_with",
+ "time",
 ]
 
 [[package]]
@@ -2757,6 +2754,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2974,7 +2982,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -3129,6 +3137,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crash-context"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3273,7 +3290,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -4140,13 +4157,12 @@ dependencies = [
 
 [[package]]
 name = "etcetera"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c7b13d0780cb82722fd59f6f57f925e143427e4a75313a6c77243bf5326ae6"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
- "home",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4224,6 +4240,17 @@ dependencies = [
  "arrayvec",
  "auto_impl",
  "bytes",
+]
+
+[[package]]
+name = "ferroid"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee93edf3c501f0035bbeffeccfed0b79e14c311f12195ec0e661e114a0f60da4"
+dependencies = [
+ "portable-atomic",
+ "rand 0.10.1",
+ "web-time",
 ]
 
 [[package]]
@@ -4682,6 +4709,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -5755,7 +5783,7 @@ dependencies = [
  "pin-project",
  "rustls 0.23.37",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.5.3",
  "soketto",
  "thiserror 2.0.18",
  "tokio",
@@ -5807,7 +5835,7 @@ dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-types",
  "rustls 0.23.37",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.5.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -5954,7 +5982,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -6607,7 +6635,7 @@ dependencies = [
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 
 [[package]]
 name = "nix"
@@ -8258,6 +8286,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -8338,6 +8367,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8375,6 +8415,12 @@ dependencies = [
  "getrandom 0.3.4",
  "serde",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -8605,7 +8651,6 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.37",
- "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -8634,20 +8679,29 @@ checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
+ "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls 0.23.37",
+ "rustls-pki-types",
+ "rustls-platform-verifier 0.6.2",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls 0.26.4",
  "tower 0.5.3",
  "tower-http",
  "tower-service",
@@ -9758,6 +9812,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.37",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.10",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs 1.0.6",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10422,7 +10497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -10440,7 +10515,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -10452,7 +10527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -11049,7 +11124,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11064,7 +11139,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -11085,7 +11160,7 @@ dependencies = [
 [[package]]
 name = "sov-api-spec"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "backon",
@@ -11109,7 +11184,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11130,7 +11205,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11151,7 +11226,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-sender"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11174,7 +11249,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11194,7 +11269,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11206,7 +11281,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -11226,7 +11301,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11261,7 +11336,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11277,7 +11352,7 @@ dependencies = [
 [[package]]
 name = "sov-cli"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11300,7 +11375,7 @@ dependencies = [
 [[package]]
 name = "sov-db"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11336,7 +11411,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -11355,7 +11430,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11373,7 +11448,7 @@ dependencies = [
 [[package]]
 name = "sov-eth-client"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -11401,7 +11476,7 @@ dependencies = [
 [[package]]
 name = "sov-eth-dev-signer"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11412,7 +11487,7 @@ dependencies = [
 [[package]]
 name = "sov-ethereum"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11443,7 +11518,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11485,7 +11560,7 @@ dependencies = [
 [[package]]
 name = "sov-evm-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -11501,7 +11576,7 @@ dependencies = [
 [[package]]
 name = "sov-full-node-configs"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "schemars 0.8.22",
@@ -11515,7 +11590,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11539,7 +11614,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -11553,7 +11628,7 @@ dependencies = [
 [[package]]
 name = "sov-ledger-apis"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11578,7 +11653,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -11601,7 +11676,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11635,7 +11710,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11656,7 +11731,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11703,7 +11778,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bech32",
@@ -11725,7 +11800,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-rollup-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11765,7 +11840,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11786,7 +11861,7 @@ dependencies = [
 [[package]]
 name = "sov-node-client"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11805,7 +11880,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11823,7 +11898,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11845,7 +11920,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11865,7 +11940,7 @@ dependencies = [
 [[package]]
 name = "sov-proxy-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11882,7 +11957,7 @@ dependencies = [
 [[package]]
 name = "sov-rest-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11906,7 +11981,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11921,7 +11996,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11951,7 +12026,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-apis"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "axum 0.8.8",
  "base64 0.22.1",
@@ -11979,7 +12054,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-full-node-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "derive_more 2.1.1",
  "rockbound",
@@ -11991,7 +12066,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -12036,7 +12111,7 @@ dependencies = [
 [[package]]
 name = "sov-rpc-eth-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12058,7 +12133,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12109,7 +12184,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -12142,7 +12217,7 @@ dependencies = [
 [[package]]
 name = "sov-soak-testing-lib"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12164,7 +12239,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -12193,7 +12268,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -12222,7 +12297,7 @@ dependencies = [
 [[package]]
 name = "sov-stf-runner"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12257,7 +12332,7 @@ dependencies = [
 [[package]]
 name = "sov-synthetic-load"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12275,7 +12350,7 @@ dependencies = [
 [[package]]
 name = "sov-test-modules"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12294,7 +12369,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12309,7 +12384,7 @@ dependencies = [
 [[package]]
 name = "sov-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12370,7 +12445,7 @@ dependencies = [
 [[package]]
 name = "sov-transaction-generator"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12404,7 +12479,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12417,7 +12492,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -12439,7 +12514,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "bech32",
  "borsh",
@@ -12456,7 +12531,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -12466,7 +12541,7 @@ dependencies = [
 [[package]]
 name = "sov-value-setter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12492,7 +12567,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -13730,9 +13805,9 @@ dependencies = [
 
 [[package]]
 name = "testcontainers"
-version = "0.25.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f3ac71069f20ecfa60c396316c283fbf35e6833a53dff551a31b5458da05edc"
+checksum = "bfd5785b5483672915ed5fe3cddf9f546802779fc1eceff0a6fb7321fac81c1e"
 dependencies = [
  "astral-tokio-tar",
  "async-trait",
@@ -13740,13 +13815,16 @@ dependencies = [
  "bytes",
  "docker_credential",
  "either",
- "etcetera 0.10.0",
+ "etcetera 0.11.0",
+ "ferroid",
  "futures",
+ "http 1.4.0",
+ "itertools 0.14.0",
  "log",
  "memchr",
  "parse-display",
  "pin-project-lite",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_with",
@@ -13754,15 +13832,14 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "ulid",
  "url",
 ]
 
 [[package]]
 name = "testcontainers-modules"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1966329d5bb3f89d33602d2db2da971fb839f9297dad16527abf4564e2ae0a6d"
+checksum = "e5985fde5befe4ffa77a052e035e16c2da86e8bae301baa9f9904ad3c494d357"
 dependencies = [
  "testcontainers",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,57 +22,57 @@ publish = false
 rust-version = "1.93"
 
 [workspace.dependencies]
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3", features = [
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f", features = [
   "evm",
 ] }
-sov-accounts = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-api-spec = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-attester-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-chain-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-bank = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-blob-storage = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-paymaster = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-capabilities = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-cli = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-hyperlane-integration = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3", features = [
+sov-accounts = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-api-spec = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-attester-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-chain-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-bank = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-blob-storage = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-paymaster = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-capabilities = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-cli = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-hyperlane-integration = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f", features = [
   "evm",
 ] }
-sov-eth-client = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-test-state-consistency = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-ledger-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-modules-rollup-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-uniqueness = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-operator-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-prover-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-revenue-share = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-rollup-full-node-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-sequencer = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-sequencer-registry = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-soak-testing-lib = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-stf-runner = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-test-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-rollup-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-universal-wallet = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-zkvm-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-build = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-ethereum = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-evm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-soak-testing = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-eip712-auth = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-rest-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-proxy-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3", features = ["native"] }
+sov-eth-client = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-test-state-consistency = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-ledger-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-modules-rollup-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-uniqueness = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-operator-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-prover-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-revenue-share = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-rollup-full-node-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-sequencer = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-sequencer-registry = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-soak-testing-lib = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-stf-runner = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-test-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-rollup-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-universal-wallet = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-zkvm-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-build = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-ethereum = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-evm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-soak-testing = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-eip712-auth = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-rest-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-proxy-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f", features = ["native"] }
 
 
 stf-starter = { path = "./crates/stf", default-features = false }

--- a/configs/celestia/rollup.toml
+++ b/configs/celestia/rollup.toml
@@ -55,12 +55,20 @@ aggregated_proof_block_jump = 1
 prover_address = "0xA6edfca3AA985Dd3CC728BFFB700933a986aC085"
 max_number_of_transitions_in_db = 100
 max_number_of_transitions_in_memory = 20
+max_number_of_aggregated_proofs_in_memory = 5
 
 
 [sequencer]
 # 7 MiB
 max_batch_size_bytes = 7340032
-max_concurrent_blobs = 128
+max_concurrent_batch_blobs = 128
+# Cap on the number of proof blobs in flight on the DA layer at any given time.
+# Keep this value LARGE. If the cap is reached the ZK aggregator interprets it
+# as "proofs are not being confirmed by the rollup on time" and triggers a full
+# rollup shutdown to avoid building an unbounded backlog. Set it high enough
+# that transient DA slowness or proving bursts cannot saturate the in-flight
+# count under normal operation.
+max_concurrent_proof_blobs = 1024
 max_allowed_node_distance_behind = 10
 rollup_address = "0xA6edfca3AA985Dd3CC728BFFB700933a986aC085"
 blob_processing_timeout_secs = 60

--- a/configs/mock/rollup.toml
+++ b/configs/mock/rollup.toml
@@ -57,12 +57,14 @@ aggregated_proof_block_jump = 1
 prover_address = "0xA6edfca3AA985Dd3CC728BFFB700933a986aC085"
 max_number_of_transitions_in_db = 100
 max_number_of_transitions_in_memory = 20
+max_number_of_aggregated_proofs_in_memory = 5
 
 
 [sequencer]
 # 7 MiB
 max_batch_size_bytes = 7340032
-max_concurrent_blobs = 128
+max_concurrent_batch_blobs = 128
+max_concurrent_proof_blobs = 1024
 max_allowed_node_distance_behind = 10
 rollup_address = "0xA6edfca3AA985Dd3CC728BFFB700933a986aC085"
 blob_processing_timeout_secs = 60

--- a/configs/mock/rollup_external_mock_da.toml
+++ b/configs/mock/rollup_external_mock_da.toml
@@ -49,12 +49,14 @@ aggregated_proof_block_jump = 1
 prover_address = "0xA6edfca3AA985Dd3CC728BFFB700933a986aC085"
 max_number_of_transitions_in_db = 100
 max_number_of_transitions_in_memory = 20
+max_number_of_aggregated_proofs_in_memory = 5
 
 
 [sequencer]
 # 7 MiB
 max_batch_size_bytes = 7340032
-max_concurrent_blobs = 128
+max_concurrent_batch_blobs = 128
+max_concurrent_proof_blobs = 1024
 max_allowed_node_distance_behind = 10
 rollup_address = "0xA6edfca3AA985Dd3CC728BFFB700933a986aC085"
 blob_processing_timeout_secs = 60

--- a/crates/provers/risc0/guest-celestia/Cargo.lock
+++ b/crates/provers/risc0/guest-celestia/Cargo.lock
@@ -2401,7 +2401,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 
 [[package]]
 name = "nmt-rs"
@@ -4018,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4050,7 +4050,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4070,7 +4070,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4089,7 +4089,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4109,7 +4109,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4121,7 +4121,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4168,7 +4168,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4184,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "borsh",
  "derivative",
@@ -4219,7 +4219,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4237,7 +4237,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4273,7 +4273,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4294,7 +4294,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -4307,7 +4307,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4321,7 +4321,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4340,7 +4340,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4370,7 +4370,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4392,7 +4392,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4410,7 +4410,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4428,7 +4428,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4447,7 +4447,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4467,7 +4467,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4482,7 +4482,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4508,7 +4508,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4528,7 +4528,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4544,7 +4544,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4567,7 +4567,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4582,7 +4582,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4595,7 +4595,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4617,7 +4617,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "bech32",
  "borsh",
@@ -4634,7 +4634,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -4644,7 +4644,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "convert_case",

--- a/crates/provers/risc0/guest-celestia/Cargo.toml
+++ b/crates/provers/risc0/guest-celestia/Cargo.toml
@@ -12,16 +12,16 @@ anyhow = { version = "1.0.95" }
 risc0-zkvm = { version = "3.0", default-features = false, features = ["std"] }
 risc0-zkvm-platform = { version = "2.2" }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["celestia_da"] }
 

--- a/crates/provers/risc0/guest-mock/Cargo.lock
+++ b/crates/provers/risc0/guest-mock/Cargo.lock
@@ -2550,7 +2550,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 
 [[package]]
 name = "nmt-rs"
@@ -4182,7 +4182,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4196,7 +4196,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4214,7 +4214,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4234,7 +4234,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4253,7 +4253,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4273,7 +4273,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4285,7 +4285,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -4305,7 +4305,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4332,7 +4332,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4348,7 +4348,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "borsh",
  "derivative",
@@ -4363,7 +4363,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4381,7 +4381,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4417,7 +4417,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4438,7 +4438,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -4451,7 +4451,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4465,7 +4465,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4486,7 +4486,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4505,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4535,7 +4535,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4557,7 +4557,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4575,7 +4575,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4593,7 +4593,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4612,7 +4612,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4632,7 +4632,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4647,7 +4647,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4673,7 +4673,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4693,7 +4693,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4709,7 +4709,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4732,7 +4732,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4747,7 +4747,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4760,7 +4760,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4782,7 +4782,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "bech32",
  "borsh",
@@ -4799,7 +4799,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -4809,7 +4809,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "convert_case",

--- a/crates/provers/risc0/guest-mock/Cargo.toml
+++ b/crates/provers/risc0/guest-mock/Cargo.toml
@@ -15,16 +15,16 @@ risc0-zkvm-platform = { version = "2.2" }
 serde = { version = "1.0.188", features = ["derive", "rc"] }
 
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f", optional = true }
 
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["mock_da"] }

--- a/crates/provers/sp1/guest-celestia/Cargo.lock
+++ b/crates/provers/sp1/guest-celestia/Cargo.lock
@@ -3544,7 +3544,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 
 [[package]]
 name = "nmt-rs"
@@ -6242,7 +6242,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6256,7 +6256,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6274,7 +6274,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6294,7 +6294,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6313,7 +6313,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6333,7 +6333,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6345,7 +6345,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -6365,7 +6365,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6392,7 +6392,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6408,7 +6408,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "borsh",
  "derivative",
@@ -6442,7 +6442,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6460,7 +6460,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6496,7 +6496,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6517,7 +6517,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -6530,7 +6530,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6543,7 +6543,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6562,7 +6562,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6592,7 +6592,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6614,7 +6614,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6632,7 +6632,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6650,7 +6650,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6669,7 +6669,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6689,7 +6689,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6704,7 +6704,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6724,7 +6724,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6740,7 +6740,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6765,7 +6765,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6788,7 +6788,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6803,7 +6803,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6816,7 +6816,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -6838,7 +6838,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "bech32",
  "borsh",
@@ -6855,7 +6855,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -6865,7 +6865,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/sp1/guest-celestia/Cargo.toml
+++ b/crates/provers/sp1/guest-celestia/Cargo.toml
@@ -12,16 +12,16 @@ anyhow = { version = "1.0.95" }
 sp1-zkvm = { version = "6.1.0" }
 stf-starter = { path = "../../../stf", default-features = false, features = ["celestia_da"] }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f", optional = true }
 
 [patch.crates-io]
 sha2-v0-9-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.9.9-sp1-6.0.0" }

--- a/crates/provers/sp1/guest-mock/Cargo.lock
+++ b/crates/provers/sp1/guest-mock/Cargo.lock
@@ -3564,7 +3564,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 
 [[package]]
 name = "nmt-rs"
@@ -6262,7 +6262,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6276,7 +6276,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6294,7 +6294,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6314,7 +6314,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6333,7 +6333,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6353,7 +6353,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6365,7 +6365,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -6385,7 +6385,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6412,7 +6412,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6428,7 +6428,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "borsh",
  "derivative",
@@ -6443,7 +6443,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6461,7 +6461,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6497,7 +6497,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6518,7 +6518,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -6531,7 +6531,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6544,7 +6544,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6565,7 +6565,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6584,7 +6584,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6614,7 +6614,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6636,7 +6636,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6654,7 +6654,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6672,7 +6672,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6691,7 +6691,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6711,7 +6711,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6726,7 +6726,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6746,7 +6746,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6762,7 +6762,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6787,7 +6787,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6810,7 +6810,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6825,7 +6825,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6838,7 +6838,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -6860,7 +6860,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "bech32",
  "borsh",
@@ -6877,7 +6877,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "proc-macro2",
  "sov-universal-wallet-macro-helpers",
@@ -6887,7 +6887,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=c756ea20c3afe486163135f3358b51e23a3e78f3#c756ea20c3afe486163135f3358b51e23a3e78f3"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f#b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/sp1/guest-mock/Cargo.toml
+++ b/crates/provers/sp1/guest-mock/Cargo.toml
@@ -10,16 +10,16 @@ resolver = "2"
 anyhow = { version = "1.0.95" }
 sp1-zkvm = { version = "6.1.0" }
 serde = { version = "1.0.188", features = ["derive", "rc"] }
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "c756ea20c3afe486163135f3358b51e23a3e78f3", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["mock_da"] }
 

--- a/crates/rollup/tests/test_helpers.rs
+++ b/crates/rollup/tests/test_helpers.rs
@@ -47,11 +47,14 @@ pub async fn start_rollup(
             max_number_of_transitions_in_db: NonZeroU64::new(100).unwrap(),
             max_number_of_transitions_in_memory: NonZeroU64::new(20).unwrap(),
             eager_proof_submission: true,
+            prover_thread_count_override: None,
+            max_number_of_aggregated_proofs_in_memory: NonZeroUsize::new(5).unwrap(),
         },
         sequencer: SequencerConfig {
             max_allowed_node_distance_behind: 10,
             max_batch_size_bytes: 1048576,
-            max_concurrent_blobs: 16,
+            max_concurrent_batch_blobs: 16,
+            max_concurrent_proof_blobs: 1024,
             automatic_batch_production: true,
             rollup_address: EthereumAddress::from_str(PROVER_ADDRESS)
                 .expect("Sequencer address is not valid"),

--- a/scripts/acceptance-test/rollup_config.toml
+++ b/scripts/acceptance-test/rollup_config.toml
@@ -58,11 +58,13 @@ aggregated_proof_block_jump = 1
 prover_address = "0xA6edfca3AA985Dd3CC728BFFB700933a986aC085"
 max_number_of_transitions_in_db = 100
 max_number_of_transitions_in_memory = 20
+max_number_of_aggregated_proofs_in_memory = 5
 
 
 [sequencer]
 max_batch_size_bytes = 4048576
-max_concurrent_blobs = 128
+max_concurrent_batch_blobs = 128
+max_concurrent_proof_blobs = 1024
 max_allowed_node_distance_behind = 10
 rollup_address = "0xA6edfca3AA985Dd3CC728BFFB700933a986aC085"
 blob_processing_timeout_secs = 60


### PR DESCRIPTION
Upgrading to latest dev on 2026-05-06 b5d4f5a7abf74af62f3a65e7d3200e1a8fc34d0f

Breaking changes resolved:
- #2808: Added required `sequencer.max_concurrent_proof_blobs = 1024` to all rollup configs and `test_helpers.rs`.
- #2805: Renamed `sequencer.max_concurrent_blobs` to `sequencer.max_concurrent_batch_blobs` in all rollup configs and `test_helpers.rs`.
- #2796: Added `proof_manager.max_number_of_aggregated_proofs_in_memory = 5` to all rollup configs; added `prover_thread_count_override: None` and `max_number_of_aggregated_proofs_in_memory: NonZeroUsize::new(5)` to the `ProofManagerConfig` literal in `test_helpers.rs`.