### PR TITLE
Add Postgresql support for mock_da_external

### DIFF
--- a/crates/rollup/Cargo.toml
+++ b/crates/rollup/Cargo.toml
@@ -72,7 +72,7 @@ sov-address = { workspace = true, features = ["evm"] }
 [features]
 default = ["mock_da", "mock_zkvm"]
 mock_da = ["sov-mock-da", "stf-starter/mock_da"]
-mock_da_external = ["sov-mock-da", "stf-starter/mock_da_external"]
+mock_da_external = ["sov-mock-da", "stf-starter/mock_da_external", "sov-mock-da/postgres"]
 celestia_da = ["sov-celestia-adapter", "stf-starter/celestia_da"]
 sp1 = ["sov-sp1-adapter", "sp1-starter"]
 risc0 = ["sov-risc0-adapter", "risc0-starter"]


### PR DESCRIPTION
Fixes this deployment issue on CDK:

```
May 21 11:47:57 ip-10-0-2-173 mock-da-server[25688]: 2026-05-21T11:47:57.696367Z  INFO mock_da_server: Starting mock-da server with configuration:
May 21 11:47:57 ip-10-0-2-173 mock-da-server[25688]: 2026-05-21T11:47:57.696381Z  INFO mock_da_server:   Host: 0.0.0.0
May 21 11:47:57 ip-10-0-2-173 mock-da-server[25688]: 2026-05-21T11:47:57.696384Z  INFO mock_da_server:   Port: 50051
May 21 11:47:57 ip-10-0-2-173 mock-da-server[25688]: 2026-05-21T11:47:57.696386Z  INFO mock_da_server:   Database: postgresql://dbadmin:,SX76eM,kdj=06WS,M0fx-xWNcOWcO@sovrollupcdkstarterstack-sovrollupmockdatabaseclus-lzakan8kegrw.cluster-ck9ecmym4umd.us-east-1.rds.amazonaws.com:5432/mock_da_postgres
May 21 11:47:57 ip-10-0-2-173 mock-da-server[25688]: 2026-05-21T11:47:57.696389Z  INFO mock_da_server:   Block producing: Periodic { block_time_ms: 6000 }
May 21 11:47:57 ip-10-0-2-173 mock-da-server[25688]: thread 'main' (25688) panicked at /home/ubuntu/.cargo/git/checkouts/sovereign-sdk-de4a3e6cb918f1e3/42d15bd/crates/adapters/mock-da/src/storable/local_service.rs:299:18:
May 21 11:47:57 ip-10-0-2-173 mock-da-server[25688]: Failed to initialize StorableMockDaLayer: PostgreSQL support for mock-da requires the `postgres` feature
May 21 11:47:57 ip-10-0-2-173 mock-da-server[25688]: note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/rollup-starter/pull/174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->