### PR TITLE
Update to the latest dev 2026-05-25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4774,15 +4774,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -5487,27 +5478,6 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "jmt"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b37ade62ca224945201e0c6d65e7a389ada90217895f7aa281470212ce4dddb0"
-dependencies = [
- "anyhow",
- "borsh",
- "digest 0.10.7",
- "hashbrown 0.13.2",
- "hex",
- "itertools 0.10.5",
- "mirai-annotations",
- "num-derive 0.3.3",
- "num-traits",
- "serde",
- "sha2 0.10.9",
- "thiserror 1.0.69",
- "tracing",
-]
 
 [[package]]
 name = "jni"
@@ -6368,12 +6338,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mirai-annotations"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
-
-[[package]]
 name = "mti"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6456,7 +6420,7 @@ dependencies = [
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 
 [[package]]
 name = "nix"
@@ -6644,17 +6608,6 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
-
-[[package]]
-name = "num-derive"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "num-derive"
@@ -8910,7 +8863,7 @@ dependencies = [
  "gdbstub",
  "gdbstub_arch",
  "malachite",
- "num-derive 0.4.2",
+ "num-derive",
  "num-traits",
  "paste",
  "postcard",
@@ -10766,7 +10719,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -10781,7 +10734,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -10802,7 +10755,7 @@ dependencies = [
 [[package]]
 name = "sov-api-spec"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "backon",
@@ -10826,7 +10779,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10846,7 +10799,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10866,7 +10819,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-sender"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10888,7 +10841,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10907,7 +10860,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10918,7 +10871,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -10938,7 +10891,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -10972,7 +10925,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10988,7 +10941,7 @@ dependencies = [
 [[package]]
 name = "sov-cli"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11011,7 +10964,7 @@ dependencies = [
 [[package]]
 name = "sov-db"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11022,7 +10975,6 @@ dependencies = [
  "digest 0.10.7",
  "futures",
  "hex",
- "jmt",
  "nomt",
  "parking_lot",
  "proptest",
@@ -11044,7 +10996,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -11062,7 +11014,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11077,7 +11029,7 @@ dependencies = [
 [[package]]
 name = "sov-eth-client"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -11104,7 +11056,7 @@ dependencies = [
 [[package]]
 name = "sov-eth-dev-signer"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11115,7 +11067,7 @@ dependencies = [
 [[package]]
 name = "sov-ethereum"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11146,7 +11098,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11187,7 +11139,7 @@ dependencies = [
 [[package]]
 name = "sov-evm-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -11203,7 +11155,7 @@ dependencies = [
 [[package]]
 name = "sov-full-node-configs"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "schemars 1.2.1",
@@ -11217,7 +11169,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11241,7 +11193,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -11254,7 +11206,7 @@ dependencies = [
 [[package]]
 name = "sov-ledger-apis"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11275,7 +11227,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -11297,7 +11249,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11331,7 +11283,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11351,7 +11303,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11398,7 +11350,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "bech32",
@@ -11420,7 +11372,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-rollup-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11459,7 +11411,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11476,7 +11428,7 @@ dependencies = [
 [[package]]
 name = "sov-node-client"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11495,7 +11447,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11508,7 +11460,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11525,7 +11477,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11545,7 +11497,7 @@ dependencies = [
 [[package]]
 name = "sov-proxy-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11562,7 +11514,7 @@ dependencies = [
 [[package]]
 name = "sov-rest-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11586,7 +11538,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11601,7 +11553,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11629,7 +11581,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-apis"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "axum 0.8.8",
  "borsh",
@@ -11650,7 +11602,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-full-node-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "derive_more 2.1.1",
  "rockbound",
@@ -11662,7 +11614,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11708,7 +11660,7 @@ dependencies = [
 [[package]]
 name = "sov-rpc-eth-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11728,7 +11680,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11774,7 +11726,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11807,7 +11759,7 @@ dependencies = [
 [[package]]
 name = "sov-soak-testing-lib"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "clap",
@@ -11825,7 +11777,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11854,7 +11806,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11863,7 +11815,6 @@ dependencies = [
  "derivative",
  "derive_more 2.1.1",
  "hex",
- "jmt",
  "nomt",
  "nomt-core",
  "proptest",
@@ -11872,7 +11823,6 @@ dependencies = [
  "sov-db",
  "sov-db-types",
  "sov-metrics",
- "sov-modules-macros",
  "sov-rollup-interface",
  "sov-universal-wallet",
  "tracing",
@@ -11881,7 +11831,7 @@ dependencies = [
 [[package]]
 name = "sov-stf-runner"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11915,7 +11865,7 @@ dependencies = [
 [[package]]
 name = "sov-synthetic-load"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11931,7 +11881,7 @@ dependencies = [
 [[package]]
 name = "sov-test-modules"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11949,7 +11899,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11964,7 +11914,7 @@ dependencies = [
 [[package]]
 name = "sov-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12025,7 +11975,7 @@ dependencies = [
 [[package]]
 name = "sov-transaction-generator"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12058,7 +12008,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12068,8 +12018,8 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet"
-version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+version = "0.4.0"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -12090,8 +12040,8 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
-version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+version = "0.4.0"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "bech32",
  "borsh",
@@ -12105,8 +12055,8 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macros"
-version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+version = "0.4.0"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -12115,7 +12065,7 @@ dependencies = [
 [[package]]
 name = "sov-value-setter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12140,7 +12090,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,57 +22,57 @@ publish = false
 rust-version = "1.93"
 
 [workspace.dependencies]
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591", features = [
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b", features = [
   "evm",
 ] }
-sov-accounts = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-api-spec = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-attester-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-chain-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-bank = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-blob-storage = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-paymaster = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-capabilities = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-cli = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-hyperlane-integration = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591", features = [
+sov-accounts = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-api-spec = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-attester-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-chain-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-bank = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-blob-storage = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-paymaster = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-capabilities = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-cli = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-hyperlane-integration = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b", features = [
   "evm",
 ] }
-sov-eth-client = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-test-state-consistency = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-ledger-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-modules-rollup-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-uniqueness = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-operator-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-prover-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-revenue-share = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-rollup-full-node-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-sequencer = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-sequencer-registry = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-soak-testing-lib = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-stf-runner = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-test-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-rollup-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-universal-wallet = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-zkvm-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-build = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-ethereum = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-evm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-soak-testing = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-eip712-auth = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-rest-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-proxy-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591", features = ["native"] }
+sov-eth-client = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-test-state-consistency = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-ledger-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-modules-rollup-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-uniqueness = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-operator-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-prover-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-revenue-share = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-rollup-full-node-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-sequencer = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-sequencer-registry = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-soak-testing-lib = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-stf-runner = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-test-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-rollup-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-universal-wallet = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-zkvm-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-build = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-ethereum = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-evm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-soak-testing = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-eip712-auth = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-rest-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-proxy-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b", features = ["native"] }
 
 
 stf-starter = { path = "./crates/stf", default-features = false }

--- a/crates/provers/risc0/guest-celestia/Cargo.lock
+++ b/crates/provers/risc0/guest-celestia/Cargo.lock
@@ -52,7 +52,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -82,7 +82,7 @@ dependencies = [
  "alloy-rlp",
  "crc",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -109,7 +109,7 @@ dependencies = [
  "k256",
  "serde",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -123,7 +123,7 @@ dependencies = [
  "borsh",
  "once_cell",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -301,7 +301,7 @@ dependencies = [
  "nybbles",
  "serde",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
@@ -906,7 +906,7 @@ dependencies = [
  "cid",
  "dashmap",
  "multihash",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -1070,7 +1070,7 @@ dependencies = [
  "sha2 0.10.9",
  "tendermint",
  "tendermint-proto",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
 ]
 
@@ -1115,7 +1115,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -1964,15 +1964,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -2178,27 +2169,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jmt"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b37ade62ca224945201e0c6d65e7a389ada90217895f7aa281470212ce4dddb0"
-dependencies = [
- "anyhow",
- "borsh",
- "digest 0.10.7",
- "hashbrown 0.13.2",
- "hex",
- "itertools 0.10.5",
- "mirai-annotations",
- "num-derive",
- "num-traits",
- "serde",
- "sha2 0.10.9",
- "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2228,7 +2198,7 @@ dependencies = [
  "http",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -2302,7 +2272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b397c7217467c5e5582fe413bc2f0e9f804367af8bc0f0374dc966f99d00f9c"
 dependencies = [
  "bytes",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -2468,12 +2438,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mirai-annotations"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
-
-[[package]]
 name = "multibase"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2503,7 +2467,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 
 [[package]]
 name = "nmt-rs"
@@ -2584,17 +2548,6 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
-
-[[package]]
-name = "num-derive"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "num-integer"
@@ -3048,7 +3001,7 @@ dependencies = [
  "prost-reflect",
  "prost-types",
  "protox-parse",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -3060,7 +3013,7 @@ dependencies = [
  "logos",
  "miette",
  "prost-types",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -4118,7 +4071,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4132,7 +4085,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4150,7 +4103,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4162,14 +4115,14 @@ dependencies = [
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4181,14 +4134,14 @@ dependencies = [
  "sov-rollup-interface",
  "sov-state",
  "strum",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4207,7 +4160,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4218,7 +4171,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -4238,7 +4191,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4258,14 +4211,14 @@ dependencies = [
  "sov-universal-wallet",
  "tendermint",
  "tendermint-proto",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4274,14 +4227,14 @@ dependencies = [
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "borsh",
  "derivative",
@@ -4315,7 +4268,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4330,7 +4283,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4359,14 +4312,14 @@ dependencies = [
  "sov-state",
  "sov-uniqueness",
  "sov-universal-wallet",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4387,7 +4340,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -4400,7 +4353,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4414,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4426,13 +4379,13 @@ dependencies = [
  "sha2 0.10.9",
  "sov-rollup-interface",
  "sov-universal-wallet",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4453,7 +4406,7 @@ dependencies = [
  "sov-state",
  "sov-universal-wallet",
  "strum",
- "thiserror 2.0.18",
+ "thiserror",
  "toml",
  "tracing",
  "unwrap-infallible",
@@ -4462,7 +4415,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4484,7 +4437,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4494,14 +4447,14 @@ dependencies = [
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4514,7 +4467,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4531,7 +4484,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4544,14 +4497,14 @@ dependencies = [
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4560,13 +4513,13 @@ dependencies = [
  "sov-bank",
  "sov-modules-api",
  "sov-sequencer-registry",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4583,7 +4536,7 @@ dependencies = [
  "sov-rollup-interface",
  "sov-universal-wallet",
  "sov-zkvm-utils",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "tracing-subscriber 0.3.23",
 ]
@@ -4591,7 +4544,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4606,13 +4559,13 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sov-universal-wallet",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4621,14 +4574,14 @@ dependencies = [
  "sov-bank",
  "sov-modules-api",
  "sov-state",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4636,13 +4589,11 @@ dependencies = [
  "derivative",
  "derive_more",
  "hex",
- "jmt",
  "nomt-core",
  "serde",
  "serde-big-array",
  "sov-db-types",
  "sov-metrics",
- "sov-modules-macros",
  "sov-rollup-interface",
  "sov-universal-wallet",
 ]
@@ -4650,7 +4601,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4665,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4675,8 +4626,8 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet"
-version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+version = "0.4.0"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4692,13 +4643,13 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "sov-universal-wallet-macros",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
-version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+version = "0.4.0"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "bech32",
  "borsh",
@@ -4712,8 +4663,8 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macros"
-version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+version = "0.4.0"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -4722,7 +4673,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -4970,31 +4921,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "thiserror-impl",
 ]
 
 [[package]]

--- a/crates/provers/risc0/guest-celestia/Cargo.toml
+++ b/crates/provers/risc0/guest-celestia/Cargo.toml
@@ -12,16 +12,16 @@ anyhow = { version = "1.0.95" }
 risc0-zkvm = { version = "3.0", default-features = false, features = ["std"] }
 risc0-zkvm-platform = { version = "2.2" }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["celestia_da"] }
 

--- a/crates/provers/risc0/guest-mock/Cargo.lock
+++ b/crates/provers/risc0/guest-mock/Cargo.lock
@@ -52,7 +52,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -82,7 +82,7 @@ dependencies = [
  "alloy-rlp",
  "crc",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -109,7 +109,7 @@ dependencies = [
  "k256",
  "serde",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -123,7 +123,7 @@ dependencies = [
  "borsh",
  "once_cell",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -301,7 +301,7 @@ dependencies = [
  "nybbles",
  "serde",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
@@ -906,7 +906,7 @@ dependencies = [
  "cid",
  "dashmap",
  "multihash",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -1070,7 +1070,7 @@ dependencies = [
  "sha2 0.10.9",
  "tendermint",
  "tendermint-proto",
- "thiserror 2.0.18",
+ "thiserror",
  "time",
 ]
 
@@ -1115,7 +1115,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -2005,15 +2005,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -2322,27 +2313,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jmt"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b37ade62ca224945201e0c6d65e7a389ada90217895f7aa281470212ce4dddb0"
-dependencies = [
- "anyhow",
- "borsh",
- "digest 0.10.7",
- "hashbrown 0.13.2",
- "hex",
- "itertools 0.10.5",
- "mirai-annotations",
- "num-derive",
- "num-traits",
- "serde",
- "sha2 0.10.9",
- "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2372,7 +2342,7 @@ dependencies = [
  "http",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -2446,7 +2416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b397c7217467c5e5582fe413bc2f0e9f804367af8bc0f0374dc966f99d00f9c"
 dependencies = [
  "bytes",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -2618,12 +2588,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mirai-annotations"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
-
-[[package]]
 name = "multibase"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2653,7 +2617,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 
 [[package]]
 name = "nmt-rs"
@@ -2734,17 +2698,6 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
-
-[[package]]
-name = "num-derive"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "num-integer"
@@ -3213,7 +3166,7 @@ dependencies = [
  "prost-reflect",
  "prost-types",
  "protox-parse",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -3225,7 +3178,7 @@ dependencies = [
  "logos",
  "miette",
  "prost-types",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -4283,7 +4236,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4297,7 +4250,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4315,7 +4268,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4327,14 +4280,14 @@ dependencies = [
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4346,14 +4299,14 @@ dependencies = [
  "sov-rollup-interface",
  "sov-state",
  "strum",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4372,7 +4325,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4383,7 +4336,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -4403,7 +4356,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4423,14 +4376,14 @@ dependencies = [
  "sov-universal-wallet",
  "tendermint",
  "tendermint-proto",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4439,14 +4392,14 @@ dependencies = [
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "borsh",
  "derivative",
@@ -4460,7 +4413,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4475,7 +4428,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4504,14 +4457,14 @@ dependencies = [
  "sov-state",
  "sov-uniqueness",
  "sov-universal-wallet",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4532,7 +4485,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -4545,7 +4498,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4559,7 +4512,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4580,7 +4533,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4592,13 +4545,13 @@ dependencies = [
  "sha2 0.10.9",
  "sov-rollup-interface",
  "sov-universal-wallet",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4619,7 +4572,7 @@ dependencies = [
  "sov-state",
  "sov-universal-wallet",
  "strum",
- "thiserror 2.0.18",
+ "thiserror",
  "toml",
  "tracing",
  "unwrap-infallible",
@@ -4628,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4650,7 +4603,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4660,14 +4613,14 @@ dependencies = [
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4680,7 +4633,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4697,7 +4650,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4710,14 +4663,14 @@ dependencies = [
  "sov-modules-api",
  "sov-rollup-interface",
  "sov-state",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4726,13 +4679,13 @@ dependencies = [
  "sov-bank",
  "sov-modules-api",
  "sov-sequencer-registry",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4749,7 +4702,7 @@ dependencies = [
  "sov-rollup-interface",
  "sov-universal-wallet",
  "sov-zkvm-utils",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "tracing-subscriber 0.3.23",
 ]
@@ -4757,7 +4710,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4772,13 +4725,13 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sov-universal-wallet",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4787,14 +4740,14 @@ dependencies = [
  "sov-bank",
  "sov-modules-api",
  "sov-state",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4802,13 +4755,11 @@ dependencies = [
  "derivative",
  "derive_more",
  "hex",
- "jmt",
  "nomt-core",
  "serde",
  "serde-big-array",
  "sov-db-types",
  "sov-metrics",
- "sov-modules-macros",
  "sov-rollup-interface",
  "sov-universal-wallet",
 ]
@@ -4816,7 +4767,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4831,7 +4782,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4841,8 +4792,8 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet"
-version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+version = "0.4.0"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4858,13 +4809,13 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "sov-universal-wallet-macros",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
-version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+version = "0.4.0"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "bech32",
  "borsh",
@@ -4878,8 +4829,8 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macros"
-version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+version = "0.4.0"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -4888,7 +4839,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -5154,31 +5105,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "thiserror-impl",
 ]
 
 [[package]]

--- a/crates/provers/risc0/guest-mock/Cargo.toml
+++ b/crates/provers/risc0/guest-mock/Cargo.toml
@@ -15,16 +15,16 @@ risc0-zkvm-platform = { version = "2.2" }
 serde = { version = "1.0.188", features = ["derive", "rc"] }
 
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b", optional = true }
 
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["mock_da"] }

--- a/crates/provers/sp1/guest-celestia/Cargo.lock
+++ b/crates/provers/sp1/guest-celestia/Cargo.lock
@@ -2595,15 +2595,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -3064,27 +3055,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jmt"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b37ade62ca224945201e0c6d65e7a389ada90217895f7aa281470212ce4dddb0"
-dependencies = [
- "anyhow",
- "borsh",
- "digest 0.10.7",
- "hashbrown 0.13.2",
- "hex",
- "itertools 0.10.5",
- "mirai-annotations",
- "num-derive",
- "num-traits",
- "serde",
- "sha2 0.10.9",
- "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3439,12 +3409,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mirai-annotations"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
-
-[[package]]
 name = "mti"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3484,7 +3448,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 
 [[package]]
 name = "nmt-rs"
@@ -3589,17 +3553,6 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
-
-[[package]]
-name = "num-derive"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "num-integer"
@@ -6147,7 +6100,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6161,7 +6114,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6179,7 +6132,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6198,7 +6151,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6217,7 +6170,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6236,7 +6189,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6247,7 +6200,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -6267,7 +6220,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6294,7 +6247,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6310,7 +6263,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "borsh",
  "derivative",
@@ -6343,7 +6296,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6358,7 +6311,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6394,7 +6347,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6415,7 +6368,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -6428,7 +6381,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6441,7 +6394,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6459,7 +6412,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6489,7 +6442,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6511,7 +6464,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6528,7 +6481,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6541,7 +6494,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6558,7 +6511,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6578,7 +6531,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6593,7 +6546,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6614,7 +6567,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6630,7 +6583,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6655,7 +6608,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6663,13 +6616,11 @@ dependencies = [
  "derivative",
  "derive_more 2.1.1",
  "hex",
- "jmt",
  "nomt-core",
  "serde",
  "serde-big-array",
  "sov-db-types",
  "sov-metrics",
- "sov-modules-macros",
  "sov-rollup-interface",
  "sov-universal-wallet",
 ]
@@ -6677,7 +6628,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6692,7 +6643,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6702,8 +6653,8 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet"
-version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+version = "0.4.0"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -6724,8 +6675,8 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
-version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+version = "0.4.0"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "bech32",
  "borsh",
@@ -6739,8 +6690,8 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macros"
-version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+version = "0.4.0"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -6749,7 +6700,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/sp1/guest-celestia/Cargo.toml
+++ b/crates/provers/sp1/guest-celestia/Cargo.toml
@@ -12,16 +12,16 @@ anyhow = { version = "1.0.95" }
 sp1-zkvm = { version = "6.2.1" }
 stf-starter = { path = "../../../stf", default-features = false, features = ["celestia_da"] }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b", optional = true }
 
 [patch.crates-io]
 sha2-v0-9-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.9.9-sp1-6.0.0" }

--- a/crates/provers/sp1/guest-mock/Cargo.lock
+++ b/crates/provers/sp1/guest-mock/Cargo.lock
@@ -2615,15 +2615,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -3084,27 +3075,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jmt"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b37ade62ca224945201e0c6d65e7a389ada90217895f7aa281470212ce4dddb0"
-dependencies = [
- "anyhow",
- "borsh",
- "digest 0.10.7",
- "hashbrown 0.13.2",
- "hex",
- "itertools 0.10.5",
- "mirai-annotations",
- "num-derive",
- "num-traits",
- "serde",
- "sha2 0.10.9",
- "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3459,12 +3429,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mirai-annotations"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
-
-[[package]]
 name = "mti"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3504,7 +3468,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 
 [[package]]
 name = "nmt-rs"
@@ -3609,17 +3573,6 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
-
-[[package]]
-name = "num-derive"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "num-integer"
@@ -6167,7 +6120,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6181,7 +6134,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6199,7 +6152,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6218,7 +6171,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6237,7 +6190,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6256,7 +6209,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6267,7 +6220,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -6287,7 +6240,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6314,7 +6267,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6330,7 +6283,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "borsh",
  "derivative",
@@ -6344,7 +6297,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6359,7 +6312,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6395,7 +6348,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6416,7 +6369,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -6429,7 +6382,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6442,7 +6395,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6463,7 +6416,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6481,7 +6434,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6511,7 +6464,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6533,7 +6486,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6550,7 +6503,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6563,7 +6516,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6580,7 +6533,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6600,7 +6553,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6615,7 +6568,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6636,7 +6589,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6652,7 +6605,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6677,7 +6630,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6685,13 +6638,11 @@ dependencies = [
  "derivative",
  "derive_more 2.1.1",
  "hex",
- "jmt",
  "nomt-core",
  "serde",
  "serde-big-array",
  "sov-db-types",
  "sov-metrics",
- "sov-modules-macros",
  "sov-rollup-interface",
  "sov-universal-wallet",
 ]
@@ -6699,7 +6650,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6714,7 +6665,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6724,8 +6675,8 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet"
-version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+version = "0.4.0"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -6746,8 +6697,8 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
-version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+version = "0.4.0"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "bech32",
  "borsh",
@@ -6761,8 +6712,8 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macros"
-version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+version = "0.4.0"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -6771,7 +6722,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=42d15bd0b34acd269e295ccb5066c55eaa7d2591#42d15bd0b34acd269e295ccb5066c55eaa7d2591"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/sp1/guest-mock/Cargo.toml
+++ b/crates/provers/sp1/guest-mock/Cargo.toml
@@ -10,16 +10,16 @@ resolver = "2"
 anyhow = { version = "1.0.95" }
 sp1-zkvm = { version = "6.2.1" }
 serde = { version = "1.0.188", features = ["derive", "rc"] }
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "42d15bd0b34acd269e295ccb5066c55eaa7d2591", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["mock_da"] }
 


### PR DESCRIPTION
Upgrading to latest dev on 2026-05-25 0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b

No breaking changes affected the starter:
- JMT removal (#2884): starter already uses NomtStorageManager
- EVM precompile generic (#2893): default generic preserves existing usage