### PR TITLE
Update to the latest dev 2026-05-26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6420,7 +6420,7 @@ dependencies = [
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 
 [[package]]
 name = "nix"
@@ -10719,7 +10719,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -10734,7 +10734,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -10755,7 +10755,7 @@ dependencies = [
 [[package]]
 name = "sov-api-spec"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "backon",
@@ -10779,7 +10779,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10799,7 +10799,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10819,7 +10819,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-sender"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10841,7 +10841,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10860,7 +10860,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10871,7 +10871,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -10891,7 +10891,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -10925,7 +10925,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10941,7 +10941,7 @@ dependencies = [
 [[package]]
 name = "sov-cli"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10964,7 +10964,7 @@ dependencies = [
 [[package]]
 name = "sov-db"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -10996,7 +10996,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -11014,7 +11014,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11029,7 +11029,7 @@ dependencies = [
 [[package]]
 name = "sov-eth-client"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -11056,7 +11056,7 @@ dependencies = [
 [[package]]
 name = "sov-eth-dev-signer"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11067,7 +11067,7 @@ dependencies = [
 [[package]]
 name = "sov-ethereum"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11098,7 +11098,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11139,7 +11139,7 @@ dependencies = [
 [[package]]
 name = "sov-evm-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -11155,7 +11155,7 @@ dependencies = [
 [[package]]
 name = "sov-full-node-configs"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "schemars 1.2.1",
@@ -11169,7 +11169,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11193,7 +11193,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -11206,7 +11206,7 @@ dependencies = [
 [[package]]
 name = "sov-ledger-apis"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11227,7 +11227,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -11249,7 +11249,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11283,7 +11283,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11303,7 +11303,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11350,7 +11350,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "bech32",
@@ -11372,7 +11372,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-rollup-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11411,7 +11411,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11428,7 +11428,7 @@ dependencies = [
 [[package]]
 name = "sov-node-client"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11447,7 +11447,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11460,7 +11460,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11477,7 +11477,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11497,7 +11497,7 @@ dependencies = [
 [[package]]
 name = "sov-proxy-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11514,7 +11514,7 @@ dependencies = [
 [[package]]
 name = "sov-rest-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11538,7 +11538,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11553,7 +11553,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11581,7 +11581,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-apis"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "axum 0.8.8",
  "borsh",
@@ -11602,7 +11602,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-full-node-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "derive_more 2.1.1",
  "rockbound",
@@ -11614,7 +11614,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11660,7 +11660,7 @@ dependencies = [
 [[package]]
 name = "sov-rpc-eth-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11680,7 +11680,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11726,7 +11726,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11759,7 +11759,7 @@ dependencies = [
 [[package]]
 name = "sov-soak-testing-lib"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "clap",
@@ -11777,7 +11777,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11806,7 +11806,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11831,7 +11831,7 @@ dependencies = [
 [[package]]
 name = "sov-stf-runner"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11865,7 +11865,7 @@ dependencies = [
 [[package]]
 name = "sov-synthetic-load"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11881,7 +11881,7 @@ dependencies = [
 [[package]]
 name = "sov-test-modules"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11899,7 +11899,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11914,7 +11914,7 @@ dependencies = [
 [[package]]
 name = "sov-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11975,7 +11975,7 @@ dependencies = [
 [[package]]
 name = "sov-transaction-generator"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12008,7 +12008,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12019,7 +12019,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -12041,7 +12041,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "bech32",
  "borsh",
@@ -12056,7 +12056,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -12065,7 +12065,7 @@ dependencies = [
 [[package]]
 name = "sov-value-setter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12090,7 +12090,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5411,6 +5411,10 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "schemars 1.2.1",
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -6420,7 +6424,7 @@ dependencies = [
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 
 [[package]]
 name = "nix"
@@ -6982,9 +6986,9 @@ dependencies = [
 
 [[package]]
 name = "p3-air"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a16a8d78c6a37d0eb66b008a18a9e8caa38c3a6a9ca9036416d509faf3dbc86"
+checksum = "d3a5de20a2301bf2530de1ceb13768ec3a80f729fbf8b72f813e30bc54c5bce2"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -6993,9 +6997,9 @@ dependencies = [
 
 [[package]]
 name = "p3-baby-bear"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d80b9c0a27092644dc22fd8fd6768dab62d325c6f7d121cf896e6bb3789779cf"
+checksum = "d69e6e9af4eaaaa60f7bb9f0e0f73ebcbaefe7e00974d97ad0fa542d6a4f0890"
 dependencies = [
  "cfg-if",
  "num-bigint 0.4.6",
@@ -7010,9 +7014,9 @@ dependencies = [
 
 [[package]]
 name = "p3-bn254-fr"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577200e3fa7e49e2b21e940a6dc7399dc63acb8581da088558cdf7c455adafc0"
+checksum = "2077757c7cb514202ccb5368f521f23f5709c720599e6545c683c66e0a52d2d8"
 dependencies = [
  "ff",
  "num-bigint 0.4.6",
@@ -7025,9 +7029,9 @@ dependencies = [
 
 [[package]]
 name = "p3-challenger"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75358edd6e2562752c01f5064a66d88144a3e75ace0407166dbdf8a727597f52"
+checksum = "b6a908924d43e4cfb93fb41c8346cac211b70314385a9037e9241f5b7f3eaf77"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -7039,9 +7043,9 @@ dependencies = [
 
 [[package]]
 name = "p3-commit"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0991de9c2f2f8c6a6667eaebe2a5495a2132f9709ffa93357dc18865d154f16"
+checksum = "50acacc7219fce6c01db938f82c1b21b5e7133990b7fff861f91534aeb569419"
 dependencies = [
  "itertools 0.12.1",
  "p3-challenger",
@@ -7053,9 +7057,9 @@ dependencies = [
 
 [[package]]
 name = "p3-dft"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761f1e1b014f2b1b69bd0309124e233d64aa3590e6a41ee786000dd849506d51"
+checksum = "be6408b10a2c27eb13a7d5580c546c2179a8dc7dbc10a990657311891f9b41c0"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -7066,9 +7070,9 @@ dependencies = [
 
 [[package]]
 name = "p3-field"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df7cebaa4079b24e0dd7e3aad59eebcbb99a67c1271f79ad884a7c032f5f183"
+checksum = "3dc75969ca3ac847f43e632ab979d59ff7a68f9eac8dbf8edcbba47fc2e1d3aa"
 dependencies = [
  "itertools 0.12.1",
  "num-bigint 0.4.6",
@@ -7080,9 +7084,9 @@ dependencies = [
 
 [[package]]
 name = "p3-fri"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ef10c7f829294e16a6248200e9571908177c0b5f35bdd70748ac3239a02d29"
+checksum = "5cbc4965ee488f3247867b7ec4bb005b8afa72cb0d461a4dcb1387ecab6426d5"
 dependencies = [
  "itertools 0.12.1",
  "p3-challenger",
@@ -7099,9 +7103,9 @@ dependencies = [
 
 [[package]]
 name = "p3-interpolation"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413812d3ada8aa10ece23fc68d47d0c23eed1decbc3844a56f9647c7199796d7"
+checksum = "08ad7e9f08c336d7ea39d12e11951188473542565323bac2a6535e536b58487d"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -7110,9 +7114,9 @@ dependencies = [
 
 [[package]]
 name = "p3-keccak-air"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a087526deb74bf12cc4efc1e50d5c387120624b15ea1de1f3efb440efbcd4d"
+checksum = "1f5bf177d56740078b5a5a842fa2393427796283dc8174b4a1a325c2d0b042de"
 dependencies = [
  "p3-air",
  "p3-field",
@@ -7124,9 +7128,9 @@ dependencies = [
 
 [[package]]
 name = "p3-koala-bear"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cea0ba3389b034b6088d566aea8b57aa29dd2e180966e0c8056f61331c92b4e"
+checksum = "3a9683cd0ef68100df7c62490533047bcf19c04c4a0fa1efc9d7c1e03e31f6b3"
 dependencies = [
  "cfg-if",
  "num-bigint 0.4.6",
@@ -7141,9 +7145,9 @@ dependencies = [
 
 [[package]]
 name = "p3-matrix"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fae5cc6ce726cc265cc687c1214e3f1ac1f5c6e973442286ba00d1e75da1c3cb"
+checksum = "75c3f150ceb90e09539413bf481e618d05ee19210b4e467d2902eb82d2e15281"
 dependencies = [
  "itertools 0.12.1",
  "p3-field",
@@ -7156,18 +7160,18 @@ dependencies = [
 
 [[package]]
 name = "p3-maybe-rayon"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac1d2f102cf8c71dba1b449575c99697781fcc028831e83d2245787bd7a650"
+checksum = "e0641952b42da45e1dfa2d4a2a3163e330f944ad9740942f35026c0a71a605f1"
 dependencies = [
  "rayon",
 ]
 
 [[package]]
 name = "p3-mds"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f072643e385d65fb9eb089ee6824b320417f78671a0db748566e057e28b250e"
+checksum = "aa4a5f250e174dcfca5cbeac6ad75713924e7e7320e0a335e3c50b8b1f4fe8ec"
 dependencies = [
  "itertools 0.12.1",
  "p3-dft",
@@ -7180,9 +7184,9 @@ dependencies = [
 
 [[package]]
 name = "p3-merkle-tree"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "946fcfa239847824c9216db8ac731611c7e82171ef51869bc89d985ad46000d0"
+checksum = "d5703d9229d52a8c09970e4d722c3a8b4d37e688c306c3a1c03b872efcd204e6"
 dependencies = [
  "itertools 0.12.1",
  "p3-commit",
@@ -7197,9 +7201,9 @@ dependencies = [
 
 [[package]]
 name = "p3-poseidon2"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00cc4b6e8a439f79541b0910a016da9e6e12a05a24309bbb713e1db0db396952"
+checksum = "522986377b2164c5f94f2dae88e0e0a3d169cc6239202ef4aeb4322d60feffd0"
 dependencies = [
  "gcd",
  "p3-field",
@@ -7211,9 +7215,9 @@ dependencies = [
 
 [[package]]
 name = "p3-symmetric"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eebff7fea7deb08a57ccf731a0ed39df25cc66a0e0c2d92c4472c4dee02ee21"
+checksum = "9047ce85c086a9b3f118e10078f10636f7bfeed5da871a04da0b61400af8793a"
 dependencies = [
  "itertools 0.12.1",
  "p3-field",
@@ -7222,9 +7226,9 @@ dependencies = [
 
 [[package]]
 name = "p3-uni-stark"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e352e1c9765674f618dbd56e33f673a688d1f85332929fcbefa0fc5e5f4373b5"
+checksum = "fc3dfdeba14d8db621c4e52dd63973384ff35f353fd750154ff88397f4ea5adf"
 dependencies = [
  "itertools 0.12.1",
  "p3-air",
@@ -7241,9 +7245,9 @@ dependencies = [
 
 [[package]]
 name = "p3-util"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8164df89bbc92e29938f916cc5f1ccbfe6a36fb5040f21ba93c1f21985b9868"
+checksum = "cff962f8eaa5f36e0447cee7c241f6b4b475fadf3ee61f154327a26bb4e009ba"
 dependencies = [
  "serde",
 ]
@@ -10229,18 +10233,18 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-air"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0f533af798f4f9095bbb2a04a91f2026acfc5c5d7578581193bcec71e6a8db"
+checksum = "4aaab798ba2ee1d2fffb3075fc303e4fd87b5b3062693a68f81adb8b508821bd"
 dependencies = [
  "p3-air",
 ]
 
 [[package]]
 name = "slop-algebra"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a473c3a06b466dd0708829415a8a9fab451740da066e07862c8c098904aaad6"
+checksum = "3e8abf7cfad18c0580576e8adc01f7fa27b1cb19432e451e82950c9a445a7cfc"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -10249,9 +10253,9 @@ dependencies = [
 
 [[package]]
 name = "slop-alloc"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69234b7c30707f1ca518d469a014bbc10d38b97e17fef5dbfd158a8269255595"
+checksum = "550acd655362b52fc00d00410f08fc5dea4d22e35eef091c09b6a37d9c79e014"
 dependencies = [
  "serde",
  "slop-algebra",
@@ -10260,9 +10264,9 @@ dependencies = [
 
 [[package]]
 name = "slop-baby-bear"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c830173902ff1d5fcb2fa8f40ef34c7d68685059a99a6b9ef91be4bb252abd"
+checksum = "3263d9487d6e632a747dd267d981e859e4f9fb97506dd8b547049116e0f49dc9"
 dependencies = [
  "lazy_static",
  "p3-baby-bear",
@@ -10275,9 +10279,9 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2dfc41465ee2a8f65afc09da3570997f3c0bf58ae57d559dd7bb05ad5b3f2a0"
+checksum = "596da7b2b980055ec1074c61f7b7f243e57f4fef81ab04f717bcc99b3391191d"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -10298,9 +10302,9 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold-prover"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fe45ae8840223fb6a1bc9cf1d97c91d0017246b168280242d75c6aa4dfb785"
+checksum = "ce348433feab7a98c2d18419c11320a63a9407a7bf360fcb1d12e98610def29d"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -10325,9 +10329,9 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7fbae5dd16a3d1e87c9e99cfd557338171710be01458bd5b12dded3878d3fd8"
+checksum = "c327e0927fabf9c0ae9a7b0333027dc04431e5981ab80d7bbe994d6c4ce35fc1"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -10340,9 +10344,9 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e80df718cef7d3100658dc8b46fafcc994b814421ec9a7d0763a6ee1e5070c"
+checksum = "c263e731bb694d4465eedae7ecd6faf1f277198e751f3c209a1c4186d80d1b6b"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -10353,9 +10357,9 @@ dependencies = [
 
 [[package]]
 name = "slop-commit"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e3b8f111af56f28eb847662fb87fa8caaee53930a13e8ecea9724163259664"
+checksum = "109134f16ae1ea59d333cb28de896bfc8ee383fb575819b6a9f78ba72f46e8ad"
 dependencies = [
  "p3-commit",
  "serde",
@@ -10364,9 +10368,9 @@ dependencies = [
 
 [[package]]
 name = "slop-dft"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29b3439e560ad36f22860c1754e2d6b8715a26dd94fd0acd46a8b07be61add7f"
+checksum = "5bac9e643a07f2138cf5faaae46ae1a16bb359d5224aa3010bbf7b0b794dfd07"
 dependencies = [
  "p3-dft",
  "serde",
@@ -10378,18 +10382,18 @@ dependencies = [
 
 [[package]]
 name = "slop-fri"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "361123ccbbd5faa10edb44c6d76b46053e2f539538a159cd952dd4d5b4606c4b"
+checksum = "407ac1bf5c4b05a4da95c9951bf32307049f3157988e4b22f65915ff58f33173"
 dependencies = [
  "p3-fri",
 ]
 
 [[package]]
 name = "slop-futures"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdae12f26b251c25144bae668d44da582ce12deb86d22ff6ebc10a84b2fc2abf"
+checksum = "ee61e1c5d07006a5221314cfe6f6f77d2168e117081fb13581f8596f7262ddd4"
 dependencies = [
  "crossbeam",
  "futures",
@@ -10402,9 +10406,9 @@ dependencies = [
 
 [[package]]
 name = "slop-jagged"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07d9667c28a67f83e42e40c74711f23c072e731e06e9c9997d2e4924d544ce6"
+checksum = "4d313a73ca824342c6468fd1c63a7e3cde89b7cf456d2f3408843100603eadab"
 dependencies = [
  "derive-where",
  "futures",
@@ -10436,18 +10440,18 @@ dependencies = [
 
 [[package]]
 name = "slop-keccak-air"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13601bdd494e77e2d431ba4f555788caf1dc5e5812df49061fedbc957e1e19e3"
+checksum = "07b7952549a449a95b4a2daa4e1861afbe94c5f22d3c0f36bf42406855f5912f"
 dependencies = [
  "p3-keccak-air",
 ]
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6586b1c0e66c503e4026a8cb007349fa99c2466957c5b09d18fe658d1391ed8"
+checksum = "0a8cdc74f04d13e738b4628312b16dfec6a2e547bde697c8bdcf556884c6e91f"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -10460,27 +10464,27 @@ dependencies = [
 
 [[package]]
 name = "slop-matrix"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44c7beb600f1e47c43c2745711cf412872999b1ce6a44b8fb5683cd0b1a64a2"
+checksum = "57b20e8f35b9ebe60aa9bc0a2b76848bb43c8130f4df85491c5d09f49aa92c45"
 dependencies = [
  "p3-matrix",
 ]
 
 [[package]]
 name = "slop-maybe-rayon"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a2e15a4db7cbc703c203c1ea00d5a889bf3ff9646e8cfd7076ef584ebca441"
+checksum = "ef79faf36b964b0b8423179e29c9c6839fd16d3f9548785b69988a50c1ea617d"
 dependencies = [
  "p3-maybe-rayon",
 ]
 
 [[package]]
 name = "slop-merkle-tree"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3d8df667dc00a44093c22564cfc0140b0ca16e41e6b0be7368822832d71d45"
+checksum = "160e61fa46d477af39d4d1b5737faaee77afe0b4106531ae22b9781686b2888e"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -10504,9 +10508,9 @@ dependencies = [
 
 [[package]]
 name = "slop-multilinear"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f33c77ba8c2c516592bc23669b47c38babdd3aed64389e368cc1f2f499f8b75e"
+checksum = "671628cc4119c29685ff484d5eb993ba483cef7915d065c993c55842b4c2f3c9"
 dependencies = [
  "derive-where",
  "futures",
@@ -10525,27 +10529,27 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c956b11fff1b8a071fa4ba982dc35e458cff1620dc7b33d9cf22d8df30895f79"
+checksum = "3aedfc3bf87cf2694bd108c039d663c346c7bb807491a7db6701eb9dff5c6e5d"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de169e0ca381847f9efa0db5a54533371c10558d7aaed4cb3b2a9bae24a0fe83"
+checksum = "f30e6e332c3cb103541bed9f5f477b769df1b5fb6076b5e2386569c94b1475dc"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-stacked"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9103802fef961c064a96457b60da838b2d4aa336b00a89fe3af948d684b8226"
+checksum = "4981970b3ea9620889b558cc859edac2ffaeabc0b444027674cf15dd11e8d433"
 dependencies = [
  "derive-where",
  "futures",
@@ -10566,9 +10570,9 @@ dependencies = [
 
 [[package]]
 name = "slop-sumcheck"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4b3d5051be430c5b47e95f8258221cb40d276fa3461d0239ca3cd96d95f4ccc"
+checksum = "f8a67f4c3d2f73c34032c13b85e22eba69ac8a677481dbbdb3f9942be12eb765"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -10584,18 +10588,18 @@ dependencies = [
 
 [[package]]
 name = "slop-symmetric"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955145ad6e3a1d083a428f9274071cfbb44c3b29013aae9d6c4c29fb7328cfc0"
+checksum = "4cb1de854325a8c36a1bdfee5514e1d4c9f39290ae19eeaecb21ca6ee88d96d6"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "slop-tensor"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84835a3d915fb0402eb7b821ba1637399e7f3d330ba8f9b6faca0317d6df7277"
+checksum = "bcf7b2a0e76f1ad8ca43aac248965e4b7448101954661f877a6e6ac7f3813dad"
 dependencies = [
  "arrayvec",
  "derive-where",
@@ -10613,18 +10617,18 @@ dependencies = [
 
 [[package]]
 name = "slop-uni-stark"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd531cc607df2b64e68ea80cc1c05584205b06e70dc5b89563f6b74ab1723f74"
+checksum = "ab33d6a10b1f4dc2edc26131bccd0955ccf5d76e7de6f15c50a9d0873f3f8603"
 dependencies = [
  "p3-uni-stark",
 ]
 
 [[package]]
 name = "slop-utils"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce2c30637af6348960554f9aea4cebce7eb172f173f2187892fcac5cceb3729"
+checksum = "9a9ff3ba185c57a0f4f3bc64e124f5c536d6db416f5f4930c46b278aade270e6"
 dependencies = [
  "p3-util",
  "tracing-forest",
@@ -10633,9 +10637,9 @@ dependencies = [
 
 [[package]]
 name = "slop-whir"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf15dc092785295fe2fd22f1057941a3d5f4d0f6f9ffdce43bb1c9fee8e5578"
+checksum = "07626b0cb8878f3884fa0f68e06ba37746181aa1e7ce0d6e95e53013c5c924e1"
 dependencies = [
  "derive-where",
  "futures",
@@ -10719,7 +10723,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -10734,7 +10738,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -10755,7 +10759,7 @@ dependencies = [
 [[package]]
 name = "sov-api-spec"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "backon",
@@ -10779,7 +10783,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10799,7 +10803,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10819,7 +10823,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-sender"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10841,7 +10845,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10860,7 +10864,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10871,7 +10875,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -10891,7 +10895,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -10925,7 +10929,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10941,7 +10945,7 @@ dependencies = [
 [[package]]
 name = "sov-cli"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10964,7 +10968,7 @@ dependencies = [
 [[package]]
 name = "sov-db"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -10996,7 +11000,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -11014,7 +11018,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11029,7 +11033,7 @@ dependencies = [
 [[package]]
 name = "sov-eth-client"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -11056,7 +11060,7 @@ dependencies = [
 [[package]]
 name = "sov-eth-dev-signer"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11067,7 +11071,7 @@ dependencies = [
 [[package]]
 name = "sov-ethereum"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11098,7 +11102,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11139,7 +11143,7 @@ dependencies = [
 [[package]]
 name = "sov-evm-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -11155,9 +11159,10 @@ dependencies = [
 [[package]]
 name = "sov-full-node-configs"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
+ "ipnet",
  "schemars 1.2.1",
  "serde",
  "sov-db",
@@ -11169,7 +11174,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11193,7 +11198,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -11206,7 +11211,7 @@ dependencies = [
 [[package]]
 name = "sov-ledger-apis"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11227,7 +11232,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -11249,7 +11254,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11283,7 +11288,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11303,7 +11308,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11350,7 +11355,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "bech32",
@@ -11372,7 +11377,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-rollup-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11411,7 +11416,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11428,7 +11433,7 @@ dependencies = [
 [[package]]
 name = "sov-node-client"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11447,7 +11452,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11460,7 +11465,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11477,7 +11482,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11497,7 +11502,7 @@ dependencies = [
 [[package]]
 name = "sov-proxy-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11514,7 +11519,7 @@ dependencies = [
 [[package]]
 name = "sov-rest-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11538,7 +11543,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11553,7 +11558,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11581,7 +11586,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-apis"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "axum 0.8.8",
  "borsh",
@@ -11602,7 +11607,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-full-node-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "derive_more 2.1.1",
  "rockbound",
@@ -11614,7 +11619,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11660,7 +11665,7 @@ dependencies = [
 [[package]]
 name = "sov-rpc-eth-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11680,7 +11685,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11694,6 +11699,7 @@ dependencies = [
  "flume",
  "futures",
  "hex",
+ "ipnet",
  "mini-moka",
  "rockbound",
  "schemars 1.2.1",
@@ -11726,7 +11732,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11759,7 +11765,7 @@ dependencies = [
 [[package]]
 name = "sov-soak-testing-lib"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "clap",
@@ -11777,7 +11783,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11806,7 +11812,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11831,7 +11837,7 @@ dependencies = [
 [[package]]
 name = "sov-stf-runner"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11865,7 +11871,7 @@ dependencies = [
 [[package]]
 name = "sov-synthetic-load"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11881,7 +11887,7 @@ dependencies = [
 [[package]]
 name = "sov-test-modules"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11899,7 +11905,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11914,7 +11920,7 @@ dependencies = [
 [[package]]
 name = "sov-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11975,7 +11981,7 @@ dependencies = [
 [[package]]
 name = "sov-transaction-generator"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12008,7 +12014,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12019,7 +12025,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -12041,7 +12047,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "bech32",
  "borsh",
@@ -12056,7 +12062,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -12065,7 +12071,7 @@ dependencies = [
 [[package]]
 name = "sov-value-setter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12090,7 +12096,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -12098,9 +12104,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "082381d1779d12762a5fb4efa150c2ebdede79a3500eb0a93bf875f7cd64efa0"
+checksum = "69df543394c6d587b0f04a281606a94721d4ea9532866204126a5c0a3a12a45c"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.18.1",
@@ -12112,9 +12118,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61464c74d36b4ab16d44011be6ec1896ee463d9369238ec9edcc1c6ce61f11fd"
+checksum = "ead1f498f7763a3b27740d77db7ef07a737cf568a3c3c85efa72bb1a4858ea6a"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -12153,9 +12159,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52434a8037fd9f19a259f6a432df02fba3ccd2e23ce6a61a50477aba59e04c6e"
+checksum = "14d0e9425daa3f50fcfa9b434e6030b64b3dfacaed3d97fd47314e5ddd851603"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -12175,9 +12181,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner-binary"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d79d7911837cf8ef8fcd1fb791f9133914e7067f8bff3e7d6ec6f0ff46cf929b"
+checksum = "6671dac7abe0391d28669cbf6b08806c07feb757c0a5fc29bac8ef6882a642df"
 dependencies = [
  "bincode",
  "crash-handler",
@@ -12190,9 +12196,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bab240796901b64aa65402d14351b37f8e955438e6ee1861e3c9219bba02691"
+checksum = "7e479b3999aa550b5ef9cadaa950a3ccbfb16ff226c5598fe632a6ee6ea1749d"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -12239,9 +12245,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac661914a8708368643c805fbc6aeadba004a0619c2f5f1fbfc1866fd37b5c10"
+checksum = "4376b39a9d40040b826555984b013bd887c4505a354993a27988a6a394155fe7"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -12260,9 +12266,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a4f810860abfdc645c4d0589d6efb9302b0d2b3beab8cc60804cb772d5acbe"
+checksum = "fe2bf01a986b185b4497d7386ce3fc35eba3fbeb5169aaa7645b61053c34f449"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12271,9 +12277,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-hypercube"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c2575307ebcd93b4320a06fb48a818669551a64a0fecf3b5666628e15f90e2"
+checksum = "ecb3ffe4a61132c3277e00f85c532fbf38c3a9287ccf10a815339fe5be48af2b"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -12320,9 +12326,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-jit"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf63168fc46696206b9a8e664283ea630bda7911eb255e1d96391787858c581"
+checksum = "208902ad494f7a101e9c8420f493bc8c42fe4f1f6a3e21b7929d084f3c2e0dce"
 dependencies = [
  "dynasmrt",
  "hashbrown 0.14.5",
@@ -12337,9 +12343,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02cd166e010c80e542585bf74585ea80eff117c361656cae43f2968cf0af12d4"
+checksum = "d0d5f56efe1d2a980d0f46083863ef4fdf715ed70cc32668c9e5725af145b8d9"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -12349,9 +12355,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df14efe799ebd675cf530c853153a4787327a2385067716dfad4ede79ff31ad"
+checksum = "13ad00052921b993af682403b378c8fe23c40382f9790f093c8fac0f30433c5e"
 dependencies = [
  "bincode",
  "blake3",
@@ -12373,9 +12379,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf089b2fc3cacd5040e6eaeec7d96dc97bfd428421492a0be939f72d48a49851"
+checksum = "3ba6d960746f9a6038834893dc5c774812c004fd846fcbf5dc00f1ea294c02ef"
 dependencies = [
  "anyhow",
  "bincode",
@@ -12437,9 +12443,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover-types"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e29236cc1217ab04fdc548dbc83c817ecbf78c348879f5dbe65649680cd2ce89"
+checksum = "ff77aba505e762effc5de8258195f11279471fa9e8a3b0815aa251be22770fd3"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -12461,9 +12467,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c809d2ff42f22ebeafac078f7fae717e50f9658bcd1a5e847c0c7d7d7bf94019"
+checksum = "bfe43147fe2a5604b1c14d10f44cb7d4304127275470f676b03593a2a00da4f2"
 dependencies = [
  "bincode",
  "itertools 0.14.0",
@@ -12501,9 +12507,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9162e3ad6f369307142a81d627c4883316f7d65b1e5a0ece3dd45780e29ea2"
+checksum = "95f8488f5a4bd212f2498a8363d0f76378328aea5cbe69658c636016797c72ab"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -12522,9 +12528,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-executor"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec793f4c6c032d141476c97fb83dd86abfe3c68f8aace603d57a3d20859a10c5"
+checksum = "ef824f774b7ffac1c3c4f58fe145e4b503ba30ef885993947d4186a448748a7c"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -12546,9 +12552,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac3939b80a23bc369c2ffc1fdb136de3fd83323fe53b03b17fbb11ea383f330"
+checksum = "e6961ae41bdca71e213d01aad4a7f664d0c95a760975a12816b2ac2d54e1e570"
 dependencies = [
  "anyhow",
  "bincode",
@@ -12570,9 +12576,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-machine"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e60fd9a5f5b9bc39e3ddb39c5ac49da32b6aa7ab63c4fef7b6bb2565c2e98b9e"
+checksum = "d741527465de17de5c3ef4f9465e77117d2a15599398f97e8fb0cf8c3e57b2f4"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -12592,9 +12598,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c15071380f43c33b3dbe5650cd5acf54a8e0af4b80a833075a56309256a383"
+checksum = "a6af1816d3855a02b002a8be12a3c1856948e45bd5e04d24316aea08717c7405"
 dependencies = [
  "alloy-primitives",
  "alloy-signer",
@@ -12652,9 +12658,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91895b72db38423e477635cf22d65a3dc9dc333a872fc2fe0cd6e8daf9661891"
+checksum = "04eea9c69efabee3fff3c24f2946963d04b62af7fdd7fc6da06b1d4853f8aca6"
 dependencies = [
  "bincode",
  "blake3",
@@ -12679,9 +12685,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa10f689c4384daf7ece04176c727e6f2e56193e10a406406aa7c9c6c8f8f478"
+checksum = "fb5732e5c4cf9e607f224a0b1a0fd90515897f731eaba33939bf9d5dcdecf4f8"
 dependencies = [
  "cfg-if",
  "critical-section",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,57 +22,57 @@ publish = false
 rust-version = "1.93"
 
 [workspace.dependencies]
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1", features = [
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6", features = [
   "evm",
 ] }
-sov-accounts = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-api-spec = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-attester-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-chain-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-bank = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-blob-storage = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-paymaster = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-capabilities = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-cli = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-hyperlane-integration = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1", features = [
+sov-accounts = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-api-spec = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-attester-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-chain-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-bank = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-blob-storage = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-paymaster = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-capabilities = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-cli = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-hyperlane-integration = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6", features = [
   "evm",
 ] }
-sov-eth-client = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-test-state-consistency = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-ledger-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-modules-rollup-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-uniqueness = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-operator-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-prover-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-revenue-share = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-rollup-full-node-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-sequencer = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-sequencer-registry = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-soak-testing-lib = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-stf-runner = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-test-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-rollup-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-universal-wallet = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-zkvm-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-build = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-ethereum = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-evm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-soak-testing = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-eip712-auth = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-rest-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-proxy-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1", features = ["native"] }
+sov-eth-client = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-test-state-consistency = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-ledger-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-modules-rollup-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-uniqueness = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-operator-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-prover-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-revenue-share = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-rollup-full-node-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-sequencer = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-sequencer-registry = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-soak-testing-lib = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-stf-runner = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-test-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-rollup-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-universal-wallet = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-zkvm-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-build = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-ethereum = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-evm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-soak-testing = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-eip712-auth = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-rest-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-proxy-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6", features = ["native"] }
 
 
 stf-starter = { path = "./crates/stf", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,57 +22,57 @@ publish = false
 rust-version = "1.93"
 
 [workspace.dependencies]
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b", features = [
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1", features = [
   "evm",
 ] }
-sov-accounts = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-api-spec = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-attester-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-chain-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-bank = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-blob-storage = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-paymaster = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-capabilities = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-cli = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-hyperlane-integration = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b", features = [
+sov-accounts = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-api-spec = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-attester-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-chain-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-bank = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-blob-storage = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-paymaster = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-capabilities = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-cli = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-hyperlane-integration = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1", features = [
   "evm",
 ] }
-sov-eth-client = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-test-state-consistency = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-ledger-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-modules-rollup-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-uniqueness = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-operator-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-prover-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-revenue-share = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-rollup-full-node-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-sequencer = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-sequencer-registry = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-soak-testing-lib = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-stf-runner = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-test-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-rollup-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-universal-wallet = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-zkvm-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-build = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-ethereum = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-evm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-soak-testing = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-eip712-auth = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-rest-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-proxy-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b", features = ["native"] }
+sov-eth-client = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-test-state-consistency = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-ledger-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-modules-rollup-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-uniqueness = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-operator-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-prover-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-revenue-share = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-rollup-full-node-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-sequencer = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-sequencer-registry = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-soak-testing-lib = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-stf-runner = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-test-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-rollup-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-universal-wallet = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-zkvm-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-build = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-ethereum = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-evm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-soak-testing = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-eip712-auth = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-rest-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-proxy-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1", features = ["native"] }
 
 
 stf-starter = { path = "./crates/stf", default-features = false }

--- a/configs/celestia/evm_pinned_cache.json
+++ b/configs/celestia/evm_pinned_cache.json
@@ -1,5 +1,3 @@
 {
-	"default_bucket_size_limit": 104857600,
-	"privileged_deployer_addresses": [],
-	"known_contracts_and_limits": {}
+  "preferred_sequencer_publish_reverted_txs": false
 }

--- a/configs/mock/evm_pinned_cache.json
+++ b/configs/mock/evm_pinned_cache.json
@@ -1,5 +1,3 @@
 {
-  "default_bucket_size_limit": 104857600,
-  "privileged_deployer_addresses": [],
-  "known_contracts_and_limits": {}
+  "preferred_sequencer_publish_reverted_txs": false
 }

--- a/crates/provers/risc0/guest-celestia/Cargo.lock
+++ b/crates/provers/risc0/guest-celestia/Cargo.lock
@@ -2467,7 +2467,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 
 [[package]]
 name = "nmt-rs"
@@ -4071,7 +4071,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4085,7 +4085,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4103,7 +4103,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4122,7 +4122,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4160,7 +4160,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4171,7 +4171,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -4191,7 +4191,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4218,7 +4218,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4234,7 +4234,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "borsh",
  "derivative",
@@ -4268,7 +4268,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4283,7 +4283,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4319,7 +4319,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4340,7 +4340,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -4353,7 +4353,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4367,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4385,7 +4385,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4415,7 +4415,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4437,7 +4437,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4454,7 +4454,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4467,7 +4467,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4484,7 +4484,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4504,7 +4504,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4519,7 +4519,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4544,7 +4544,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4565,7 +4565,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4581,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4601,7 +4601,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4616,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4627,7 +4627,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4649,7 +4649,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "bech32",
  "borsh",
@@ -4664,7 +4664,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -4673,7 +4673,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/risc0/guest-celestia/Cargo.lock
+++ b/crates/provers/risc0/guest-celestia/Cargo.lock
@@ -2467,7 +2467,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 
 [[package]]
 name = "nmt-rs"
@@ -4071,7 +4071,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4085,7 +4085,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4103,7 +4103,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4122,7 +4122,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4160,7 +4160,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4171,7 +4171,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -4191,7 +4191,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4218,7 +4218,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4234,7 +4234,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "borsh",
  "derivative",
@@ -4268,7 +4268,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4283,7 +4283,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4319,7 +4319,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4340,7 +4340,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -4353,7 +4353,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4367,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4385,7 +4385,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4415,7 +4415,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4437,7 +4437,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4454,7 +4454,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4467,7 +4467,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4484,7 +4484,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4504,7 +4504,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4519,7 +4519,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4544,7 +4544,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4565,7 +4565,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4581,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4601,7 +4601,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4616,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4627,7 +4627,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4649,7 +4649,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "bech32",
  "borsh",
@@ -4664,7 +4664,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -4673,7 +4673,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/risc0/guest-celestia/Cargo.toml
+++ b/crates/provers/risc0/guest-celestia/Cargo.toml
@@ -12,16 +12,16 @@ anyhow = { version = "1.0.95" }
 risc0-zkvm = { version = "3.0", default-features = false, features = ["std"] }
 risc0-zkvm-platform = { version = "2.2" }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["celestia_da"] }
 

--- a/crates/provers/risc0/guest-celestia/Cargo.toml
+++ b/crates/provers/risc0/guest-celestia/Cargo.toml
@@ -12,16 +12,16 @@ anyhow = { version = "1.0.95" }
 risc0-zkvm = { version = "3.0", default-features = false, features = ["std"] }
 risc0-zkvm-platform = { version = "2.2" }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["celestia_da"] }
 

--- a/crates/provers/risc0/guest-mock/Cargo.lock
+++ b/crates/provers/risc0/guest-mock/Cargo.lock
@@ -2617,7 +2617,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 
 [[package]]
 name = "nmt-rs"
@@ -4236,7 +4236,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4250,7 +4250,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4268,7 +4268,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4287,7 +4287,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4306,7 +4306,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4325,7 +4325,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4336,7 +4336,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -4356,7 +4356,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4383,7 +4383,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4399,7 +4399,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "borsh",
  "derivative",
@@ -4413,7 +4413,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4428,7 +4428,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4464,7 +4464,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4485,7 +4485,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -4498,7 +4498,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4512,7 +4512,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4533,7 +4533,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4551,7 +4551,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4581,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4603,7 +4603,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4620,7 +4620,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4633,7 +4633,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4650,7 +4650,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4670,7 +4670,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4685,7 +4685,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4710,7 +4710,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4731,7 +4731,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4747,7 +4747,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4767,7 +4767,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4782,7 +4782,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4793,7 +4793,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4815,7 +4815,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "bech32",
  "borsh",
@@ -4830,7 +4830,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -4839,7 +4839,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/risc0/guest-mock/Cargo.lock
+++ b/crates/provers/risc0/guest-mock/Cargo.lock
@@ -2617,7 +2617,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 
 [[package]]
 name = "nmt-rs"
@@ -4236,7 +4236,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4250,7 +4250,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4268,7 +4268,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4287,7 +4287,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4306,7 +4306,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4325,7 +4325,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4336,7 +4336,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -4356,7 +4356,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4383,7 +4383,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4399,7 +4399,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "borsh",
  "derivative",
@@ -4413,7 +4413,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4428,7 +4428,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4464,7 +4464,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4485,7 +4485,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -4498,7 +4498,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4512,7 +4512,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4533,7 +4533,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4551,7 +4551,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4581,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4603,7 +4603,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4620,7 +4620,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4633,7 +4633,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4650,7 +4650,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4670,7 +4670,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4685,7 +4685,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4710,7 +4710,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4731,7 +4731,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4747,7 +4747,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4767,7 +4767,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4782,7 +4782,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4793,7 +4793,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4815,7 +4815,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "bech32",
  "borsh",
@@ -4830,7 +4830,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -4839,7 +4839,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/risc0/guest-mock/Cargo.toml
+++ b/crates/provers/risc0/guest-mock/Cargo.toml
@@ -15,16 +15,16 @@ risc0-zkvm-platform = { version = "2.2" }
 serde = { version = "1.0.188", features = ["derive", "rc"] }
 
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6", optional = true }
 
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["mock_da"] }

--- a/crates/provers/risc0/guest-mock/Cargo.toml
+++ b/crates/provers/risc0/guest-mock/Cargo.toml
@@ -15,16 +15,16 @@ risc0-zkvm-platform = { version = "2.2" }
 serde = { version = "1.0.188", features = ["derive", "rc"] }
 
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1", optional = true }
 
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["mock_da"] }

--- a/crates/provers/sp1/Cargo.toml
+++ b/crates/provers/sp1/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 lazy_static = { workspace = true }
 
 [build-dependencies]
-sp1-build = { version = "6.2.1", default-features = false }
+sp1-build = { version = "6.2.2", default-features = false }
 sov-zkvm-utils = { workspace = true }
 
 

--- a/crates/provers/sp1/guest-celestia/Cargo.lock
+++ b/crates/provers/sp1/guest-celestia/Cargo.lock
@@ -3448,7 +3448,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 
 [[package]]
 name = "nmt-rs"
@@ -3747,9 +3747,9 @@ dependencies = [
 
 [[package]]
 name = "p3-air"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a16a8d78c6a37d0eb66b008a18a9e8caa38c3a6a9ca9036416d509faf3dbc86"
+checksum = "d3a5de20a2301bf2530de1ceb13768ec3a80f729fbf8b72f813e30bc54c5bce2"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -3758,9 +3758,9 @@ dependencies = [
 
 [[package]]
 name = "p3-baby-bear"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d80b9c0a27092644dc22fd8fd6768dab62d325c6f7d121cf896e6bb3789779cf"
+checksum = "d69e6e9af4eaaaa60f7bb9f0e0f73ebcbaefe7e00974d97ad0fa542d6a4f0890"
 dependencies = [
  "cfg-if",
  "num-bigint 0.4.6",
@@ -3775,9 +3775,9 @@ dependencies = [
 
 [[package]]
 name = "p3-bn254-fr"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577200e3fa7e49e2b21e940a6dc7399dc63acb8581da088558cdf7c455adafc0"
+checksum = "2077757c7cb514202ccb5368f521f23f5709c720599e6545c683c66e0a52d2d8"
 dependencies = [
  "ff",
  "num-bigint 0.4.6",
@@ -3790,9 +3790,9 @@ dependencies = [
 
 [[package]]
 name = "p3-challenger"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75358edd6e2562752c01f5064a66d88144a3e75ace0407166dbdf8a727597f52"
+checksum = "b6a908924d43e4cfb93fb41c8346cac211b70314385a9037e9241f5b7f3eaf77"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -3804,9 +3804,9 @@ dependencies = [
 
 [[package]]
 name = "p3-commit"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0991de9c2f2f8c6a6667eaebe2a5495a2132f9709ffa93357dc18865d154f16"
+checksum = "50acacc7219fce6c01db938f82c1b21b5e7133990b7fff861f91534aeb569419"
 dependencies = [
  "itertools 0.12.1",
  "p3-challenger",
@@ -3818,9 +3818,9 @@ dependencies = [
 
 [[package]]
 name = "p3-dft"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761f1e1b014f2b1b69bd0309124e233d64aa3590e6a41ee786000dd849506d51"
+checksum = "be6408b10a2c27eb13a7d5580c546c2179a8dc7dbc10a990657311891f9b41c0"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -3831,9 +3831,9 @@ dependencies = [
 
 [[package]]
 name = "p3-field"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df7cebaa4079b24e0dd7e3aad59eebcbb99a67c1271f79ad884a7c032f5f183"
+checksum = "3dc75969ca3ac847f43e632ab979d59ff7a68f9eac8dbf8edcbba47fc2e1d3aa"
 dependencies = [
  "itertools 0.12.1",
  "num-bigint 0.4.6",
@@ -3845,9 +3845,9 @@ dependencies = [
 
 [[package]]
 name = "p3-fri"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ef10c7f829294e16a6248200e9571908177c0b5f35bdd70748ac3239a02d29"
+checksum = "5cbc4965ee488f3247867b7ec4bb005b8afa72cb0d461a4dcb1387ecab6426d5"
 dependencies = [
  "itertools 0.12.1",
  "p3-challenger",
@@ -3864,9 +3864,9 @@ dependencies = [
 
 [[package]]
 name = "p3-interpolation"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413812d3ada8aa10ece23fc68d47d0c23eed1decbc3844a56f9647c7199796d7"
+checksum = "08ad7e9f08c336d7ea39d12e11951188473542565323bac2a6535e536b58487d"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -3875,9 +3875,9 @@ dependencies = [
 
 [[package]]
 name = "p3-keccak-air"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a087526deb74bf12cc4efc1e50d5c387120624b15ea1de1f3efb440efbcd4d"
+checksum = "1f5bf177d56740078b5a5a842fa2393427796283dc8174b4a1a325c2d0b042de"
 dependencies = [
  "p3-air",
  "p3-field",
@@ -3889,9 +3889,9 @@ dependencies = [
 
 [[package]]
 name = "p3-koala-bear"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cea0ba3389b034b6088d566aea8b57aa29dd2e180966e0c8056f61331c92b4e"
+checksum = "3a9683cd0ef68100df7c62490533047bcf19c04c4a0fa1efc9d7c1e03e31f6b3"
 dependencies = [
  "cfg-if",
  "num-bigint 0.4.6",
@@ -3906,9 +3906,9 @@ dependencies = [
 
 [[package]]
 name = "p3-matrix"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fae5cc6ce726cc265cc687c1214e3f1ac1f5c6e973442286ba00d1e75da1c3cb"
+checksum = "75c3f150ceb90e09539413bf481e618d05ee19210b4e467d2902eb82d2e15281"
 dependencies = [
  "itertools 0.12.1",
  "p3-field",
@@ -3921,18 +3921,18 @@ dependencies = [
 
 [[package]]
 name = "p3-maybe-rayon"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac1d2f102cf8c71dba1b449575c99697781fcc028831e83d2245787bd7a650"
+checksum = "e0641952b42da45e1dfa2d4a2a3163e330f944ad9740942f35026c0a71a605f1"
 dependencies = [
  "rayon",
 ]
 
 [[package]]
 name = "p3-mds"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f072643e385d65fb9eb089ee6824b320417f78671a0db748566e057e28b250e"
+checksum = "aa4a5f250e174dcfca5cbeac6ad75713924e7e7320e0a335e3c50b8b1f4fe8ec"
 dependencies = [
  "itertools 0.12.1",
  "p3-dft",
@@ -3945,9 +3945,9 @@ dependencies = [
 
 [[package]]
 name = "p3-merkle-tree"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "946fcfa239847824c9216db8ac731611c7e82171ef51869bc89d985ad46000d0"
+checksum = "d5703d9229d52a8c09970e4d722c3a8b4d37e688c306c3a1c03b872efcd204e6"
 dependencies = [
  "itertools 0.12.1",
  "p3-commit",
@@ -3962,9 +3962,9 @@ dependencies = [
 
 [[package]]
 name = "p3-poseidon2"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00cc4b6e8a439f79541b0910a016da9e6e12a05a24309bbb713e1db0db396952"
+checksum = "522986377b2164c5f94f2dae88e0e0a3d169cc6239202ef4aeb4322d60feffd0"
 dependencies = [
  "gcd",
  "p3-field",
@@ -3976,9 +3976,9 @@ dependencies = [
 
 [[package]]
 name = "p3-symmetric"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eebff7fea7deb08a57ccf731a0ed39df25cc66a0e0c2d92c4472c4dee02ee21"
+checksum = "9047ce85c086a9b3f118e10078f10636f7bfeed5da871a04da0b61400af8793a"
 dependencies = [
  "itertools 0.12.1",
  "p3-field",
@@ -3987,9 +3987,9 @@ dependencies = [
 
 [[package]]
 name = "p3-uni-stark"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e352e1c9765674f618dbd56e33f673a688d1f85332929fcbefa0fc5e5f4373b5"
+checksum = "fc3dfdeba14d8db621c4e52dd63973384ff35f353fd750154ff88397f4ea5adf"
 dependencies = [
  "itertools 0.12.1",
  "p3-air",
@@ -4006,9 +4006,9 @@ dependencies = [
 
 [[package]]
 name = "p3-util"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8164df89bbc92e29938f916cc5f1ccbfe6a36fb5040f21ba93c1f21985b9868"
+checksum = "cff962f8eaa5f36e0447cee7c241f6b4b475fadf3ee61f154327a26bb4e009ba"
 dependencies = [
  "serde",
 ]
@@ -5626,18 +5626,18 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-air"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0f533af798f4f9095bbb2a04a91f2026acfc5c5d7578581193bcec71e6a8db"
+checksum = "4aaab798ba2ee1d2fffb3075fc303e4fd87b5b3062693a68f81adb8b508821bd"
 dependencies = [
  "p3-air",
 ]
 
 [[package]]
 name = "slop-algebra"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a473c3a06b466dd0708829415a8a9fab451740da066e07862c8c098904aaad6"
+checksum = "3e8abf7cfad18c0580576e8adc01f7fa27b1cb19432e451e82950c9a445a7cfc"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -5646,9 +5646,9 @@ dependencies = [
 
 [[package]]
 name = "slop-alloc"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69234b7c30707f1ca518d469a014bbc10d38b97e17fef5dbfd158a8269255595"
+checksum = "550acd655362b52fc00d00410f08fc5dea4d22e35eef091c09b6a37d9c79e014"
 dependencies = [
  "serde",
  "slop-algebra",
@@ -5657,9 +5657,9 @@ dependencies = [
 
 [[package]]
 name = "slop-baby-bear"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c830173902ff1d5fcb2fa8f40ef34c7d68685059a99a6b9ef91be4bb252abd"
+checksum = "3263d9487d6e632a747dd267d981e859e4f9fb97506dd8b547049116e0f49dc9"
 dependencies = [
  "lazy_static",
  "p3-baby-bear",
@@ -5672,9 +5672,9 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2dfc41465ee2a8f65afc09da3570997f3c0bf58ae57d559dd7bb05ad5b3f2a0"
+checksum = "596da7b2b980055ec1074c61f7b7f243e57f4fef81ab04f717bcc99b3391191d"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -5695,9 +5695,9 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold-prover"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fe45ae8840223fb6a1bc9cf1d97c91d0017246b168280242d75c6aa4dfb785"
+checksum = "ce348433feab7a98c2d18419c11320a63a9407a7bf360fcb1d12e98610def29d"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -5722,9 +5722,9 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7fbae5dd16a3d1e87c9e99cfd557338171710be01458bd5b12dded3878d3fd8"
+checksum = "c327e0927fabf9c0ae9a7b0333027dc04431e5981ab80d7bbe994d6c4ce35fc1"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -5737,9 +5737,9 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e80df718cef7d3100658dc8b46fafcc994b814421ec9a7d0763a6ee1e5070c"
+checksum = "c263e731bb694d4465eedae7ecd6faf1f277198e751f3c209a1c4186d80d1b6b"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -5750,9 +5750,9 @@ dependencies = [
 
 [[package]]
 name = "slop-commit"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e3b8f111af56f28eb847662fb87fa8caaee53930a13e8ecea9724163259664"
+checksum = "109134f16ae1ea59d333cb28de896bfc8ee383fb575819b6a9f78ba72f46e8ad"
 dependencies = [
  "p3-commit",
  "serde",
@@ -5761,9 +5761,9 @@ dependencies = [
 
 [[package]]
 name = "slop-dft"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29b3439e560ad36f22860c1754e2d6b8715a26dd94fd0acd46a8b07be61add7f"
+checksum = "5bac9e643a07f2138cf5faaae46ae1a16bb359d5224aa3010bbf7b0b794dfd07"
 dependencies = [
  "p3-dft",
  "serde",
@@ -5775,18 +5775,18 @@ dependencies = [
 
 [[package]]
 name = "slop-fri"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "361123ccbbd5faa10edb44c6d76b46053e2f539538a159cd952dd4d5b4606c4b"
+checksum = "407ac1bf5c4b05a4da95c9951bf32307049f3157988e4b22f65915ff58f33173"
 dependencies = [
  "p3-fri",
 ]
 
 [[package]]
 name = "slop-futures"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdae12f26b251c25144bae668d44da582ce12deb86d22ff6ebc10a84b2fc2abf"
+checksum = "ee61e1c5d07006a5221314cfe6f6f77d2168e117081fb13581f8596f7262ddd4"
 dependencies = [
  "crossbeam",
  "futures",
@@ -5799,9 +5799,9 @@ dependencies = [
 
 [[package]]
 name = "slop-jagged"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07d9667c28a67f83e42e40c74711f23c072e731e06e9c9997d2e4924d544ce6"
+checksum = "4d313a73ca824342c6468fd1c63a7e3cde89b7cf456d2f3408843100603eadab"
 dependencies = [
  "derive-where",
  "futures",
@@ -5833,18 +5833,18 @@ dependencies = [
 
 [[package]]
 name = "slop-keccak-air"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13601bdd494e77e2d431ba4f555788caf1dc5e5812df49061fedbc957e1e19e3"
+checksum = "07b7952549a449a95b4a2daa4e1861afbe94c5f22d3c0f36bf42406855f5912f"
 dependencies = [
  "p3-keccak-air",
 ]
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6586b1c0e66c503e4026a8cb007349fa99c2466957c5b09d18fe658d1391ed8"
+checksum = "0a8cdc74f04d13e738b4628312b16dfec6a2e547bde697c8bdcf556884c6e91f"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -5857,27 +5857,27 @@ dependencies = [
 
 [[package]]
 name = "slop-matrix"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44c7beb600f1e47c43c2745711cf412872999b1ce6a44b8fb5683cd0b1a64a2"
+checksum = "57b20e8f35b9ebe60aa9bc0a2b76848bb43c8130f4df85491c5d09f49aa92c45"
 dependencies = [
  "p3-matrix",
 ]
 
 [[package]]
 name = "slop-maybe-rayon"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a2e15a4db7cbc703c203c1ea00d5a889bf3ff9646e8cfd7076ef584ebca441"
+checksum = "ef79faf36b964b0b8423179e29c9c6839fd16d3f9548785b69988a50c1ea617d"
 dependencies = [
  "p3-maybe-rayon",
 ]
 
 [[package]]
 name = "slop-merkle-tree"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3d8df667dc00a44093c22564cfc0140b0ca16e41e6b0be7368822832d71d45"
+checksum = "160e61fa46d477af39d4d1b5737faaee77afe0b4106531ae22b9781686b2888e"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -5901,9 +5901,9 @@ dependencies = [
 
 [[package]]
 name = "slop-multilinear"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f33c77ba8c2c516592bc23669b47c38babdd3aed64389e368cc1f2f499f8b75e"
+checksum = "671628cc4119c29685ff484d5eb993ba483cef7915d065c993c55842b4c2f3c9"
 dependencies = [
  "derive-where",
  "futures",
@@ -5922,27 +5922,27 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c956b11fff1b8a071fa4ba982dc35e458cff1620dc7b33d9cf22d8df30895f79"
+checksum = "3aedfc3bf87cf2694bd108c039d663c346c7bb807491a7db6701eb9dff5c6e5d"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de169e0ca381847f9efa0db5a54533371c10558d7aaed4cb3b2a9bae24a0fe83"
+checksum = "f30e6e332c3cb103541bed9f5f477b769df1b5fb6076b5e2386569c94b1475dc"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-stacked"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9103802fef961c064a96457b60da838b2d4aa336b00a89fe3af948d684b8226"
+checksum = "4981970b3ea9620889b558cc859edac2ffaeabc0b444027674cf15dd11e8d433"
 dependencies = [
  "derive-where",
  "futures",
@@ -5963,9 +5963,9 @@ dependencies = [
 
 [[package]]
 name = "slop-sumcheck"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4b3d5051be430c5b47e95f8258221cb40d276fa3461d0239ca3cd96d95f4ccc"
+checksum = "f8a67f4c3d2f73c34032c13b85e22eba69ac8a677481dbbdb3f9942be12eb765"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -5981,18 +5981,18 @@ dependencies = [
 
 [[package]]
 name = "slop-symmetric"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955145ad6e3a1d083a428f9274071cfbb44c3b29013aae9d6c4c29fb7328cfc0"
+checksum = "4cb1de854325a8c36a1bdfee5514e1d4c9f39290ae19eeaecb21ca6ee88d96d6"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "slop-tensor"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84835a3d915fb0402eb7b821ba1637399e7f3d330ba8f9b6faca0317d6df7277"
+checksum = "bcf7b2a0e76f1ad8ca43aac248965e4b7448101954661f877a6e6ac7f3813dad"
 dependencies = [
  "arrayvec",
  "derive-where",
@@ -6010,18 +6010,18 @@ dependencies = [
 
 [[package]]
 name = "slop-uni-stark"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd531cc607df2b64e68ea80cc1c05584205b06e70dc5b89563f6b74ab1723f74"
+checksum = "ab33d6a10b1f4dc2edc26131bccd0955ccf5d76e7de6f15c50a9d0873f3f8603"
 dependencies = [
  "p3-uni-stark",
 ]
 
 [[package]]
 name = "slop-utils"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce2c30637af6348960554f9aea4cebce7eb172f173f2187892fcac5cceb3729"
+checksum = "9a9ff3ba185c57a0f4f3bc64e124f5c536d6db416f5f4930c46b278aade270e6"
 dependencies = [
  "p3-util",
  "tracing-forest",
@@ -6030,9 +6030,9 @@ dependencies = [
 
 [[package]]
 name = "slop-whir"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf15dc092785295fe2fd22f1057941a3d5f4d0f6f9ffdce43bb1c9fee8e5578"
+checksum = "07626b0cb8878f3884fa0f68e06ba37746181aa1e7ce0d6e95e53013c5c924e1"
 dependencies = [
  "derive-where",
  "futures",
@@ -6100,7 +6100,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6114,7 +6114,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6132,7 +6132,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6151,7 +6151,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6170,7 +6170,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6189,7 +6189,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6200,7 +6200,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -6220,7 +6220,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6247,7 +6247,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6263,7 +6263,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "borsh",
  "derivative",
@@ -6296,7 +6296,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6311,7 +6311,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6347,7 +6347,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6368,7 +6368,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -6381,7 +6381,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6394,7 +6394,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6412,7 +6412,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6442,7 +6442,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6464,7 +6464,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6481,7 +6481,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6494,7 +6494,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6511,7 +6511,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6531,7 +6531,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6546,7 +6546,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6567,7 +6567,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6583,7 +6583,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6608,7 +6608,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6628,7 +6628,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6643,7 +6643,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6654,7 +6654,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -6676,7 +6676,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "bech32",
  "borsh",
@@ -6691,7 +6691,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -6700,7 +6700,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -6708,9 +6708,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "082381d1779d12762a5fb4efa150c2ebdede79a3500eb0a93bf875f7cd64efa0"
+checksum = "69df543394c6d587b0f04a281606a94721d4ea9532866204126a5c0a3a12a45c"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -6722,9 +6722,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61464c74d36b4ab16d44011be6ec1896ee463d9369238ec9edcc1c6ce61f11fd"
+checksum = "ead1f498f7763a3b27740d77db7ef07a737cf568a3c3c85efa72bb1a4858ea6a"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -6763,9 +6763,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52434a8037fd9f19a259f6a432df02fba3ccd2e23ce6a61a50477aba59e04c6e"
+checksum = "14d0e9425daa3f50fcfa9b434e6030b64b3dfacaed3d97fd47314e5ddd851603"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -6785,9 +6785,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner-binary"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d79d7911837cf8ef8fcd1fb791f9133914e7067f8bff3e7d6ec6f0ff46cf929b"
+checksum = "6671dac7abe0391d28669cbf6b08806c07feb757c0a5fc29bac8ef6882a642df"
 dependencies = [
  "bincode",
  "crash-handler",
@@ -6800,9 +6800,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bab240796901b64aa65402d14351b37f8e955438e6ee1861e3c9219bba02691"
+checksum = "7e479b3999aa550b5ef9cadaa950a3ccbfb16ff226c5598fe632a6ee6ea1749d"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -6849,9 +6849,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac661914a8708368643c805fbc6aeadba004a0619c2f5f1fbfc1866fd37b5c10"
+checksum = "4376b39a9d40040b826555984b013bd887c4505a354993a27988a6a394155fe7"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -6870,9 +6870,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a4f810860abfdc645c4d0589d6efb9302b0d2b3beab8cc60804cb772d5acbe"
+checksum = "fe2bf01a986b185b4497d7386ce3fc35eba3fbeb5169aaa7645b61053c34f449"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6881,9 +6881,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-hypercube"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c2575307ebcd93b4320a06fb48a818669551a64a0fecf3b5666628e15f90e2"
+checksum = "ecb3ffe4a61132c3277e00f85c532fbf38c3a9287ccf10a815339fe5be48af2b"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -6930,9 +6930,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-jit"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf63168fc46696206b9a8e664283ea630bda7911eb255e1d96391787858c581"
+checksum = "208902ad494f7a101e9c8420f493bc8c42fe4f1f6a3e21b7929d084f3c2e0dce"
 dependencies = [
  "dynasmrt",
  "hashbrown 0.14.5",
@@ -6947,9 +6947,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02cd166e010c80e542585bf74585ea80eff117c361656cae43f2968cf0af12d4"
+checksum = "d0d5f56efe1d2a980d0f46083863ef4fdf715ed70cc32668c9e5725af145b8d9"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -6959,9 +6959,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df14efe799ebd675cf530c853153a4787327a2385067716dfad4ede79ff31ad"
+checksum = "13ad00052921b993af682403b378c8fe23c40382f9790f093c8fac0f30433c5e"
 dependencies = [
  "bincode",
  "blake3",
@@ -6983,9 +6983,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf089b2fc3cacd5040e6eaeec7d96dc97bfd428421492a0be939f72d48a49851"
+checksum = "3ba6d960746f9a6038834893dc5c774812c004fd846fcbf5dc00f1ea294c02ef"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7047,9 +7047,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover-types"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e29236cc1217ab04fdc548dbc83c817ecbf78c348879f5dbe65649680cd2ce89"
+checksum = "ff77aba505e762effc5de8258195f11279471fa9e8a3b0815aa251be22770fd3"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -7071,9 +7071,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c809d2ff42f22ebeafac078f7fae717e50f9658bcd1a5e847c0c7d7d7bf94019"
+checksum = "bfe43147fe2a5604b1c14d10f44cb7d4304127275470f676b03593a2a00da4f2"
 dependencies = [
  "bincode",
  "itertools 0.14.0",
@@ -7111,9 +7111,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9162e3ad6f369307142a81d627c4883316f7d65b1e5a0ece3dd45780e29ea2"
+checksum = "95f8488f5a4bd212f2498a8363d0f76378328aea5cbe69658c636016797c72ab"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -7132,9 +7132,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-executor"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec793f4c6c032d141476c97fb83dd86abfe3c68f8aace603d57a3d20859a10c5"
+checksum = "ef824f774b7ffac1c3c4f58fe145e4b503ba30ef885993947d4186a448748a7c"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -7156,9 +7156,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac3939b80a23bc369c2ffc1fdb136de3fd83323fe53b03b17fbb11ea383f330"
+checksum = "e6961ae41bdca71e213d01aad4a7f664d0c95a760975a12816b2ac2d54e1e570"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7180,9 +7180,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-machine"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e60fd9a5f5b9bc39e3ddb39c5ac49da32b6aa7ab63c4fef7b6bb2565c2e98b9e"
+checksum = "d741527465de17de5c3ef4f9465e77117d2a15599398f97e8fb0cf8c3e57b2f4"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.6",
@@ -7202,9 +7202,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c15071380f43c33b3dbe5650cd5acf54a8e0af4b80a833075a56309256a383"
+checksum = "a6af1816d3855a02b002a8be12a3c1856948e45bd5e04d24316aea08717c7405"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7239,9 +7239,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91895b72db38423e477635cf22d65a3dc9dc333a872fc2fe0cd6e8daf9661891"
+checksum = "04eea9c69efabee3fff3c24f2946963d04b62af7fdd7fc6da06b1d4853f8aca6"
 dependencies = [
  "bincode",
  "blake3",
@@ -7266,9 +7266,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa10f689c4384daf7ece04176c727e6f2e56193e10a406406aa7c9c6c8f8f478"
+checksum = "fb5732e5c4cf9e607f224a0b1a0fd90515897f731eaba33939bf9d5dcdecf4f8"
 dependencies = [
  "cfg-if",
  "critical-section",

--- a/crates/provers/sp1/guest-celestia/Cargo.lock
+++ b/crates/provers/sp1/guest-celestia/Cargo.lock
@@ -3448,7 +3448,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 
 [[package]]
 name = "nmt-rs"
@@ -6100,7 +6100,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6114,7 +6114,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6132,7 +6132,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6151,7 +6151,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6170,7 +6170,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6189,7 +6189,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6200,7 +6200,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -6220,7 +6220,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6247,7 +6247,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6263,7 +6263,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "borsh",
  "derivative",
@@ -6296,7 +6296,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6311,7 +6311,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6347,7 +6347,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6368,7 +6368,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -6381,7 +6381,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6394,7 +6394,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6412,7 +6412,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6442,7 +6442,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6464,7 +6464,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6481,7 +6481,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6494,7 +6494,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6511,7 +6511,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6531,7 +6531,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6546,7 +6546,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6567,7 +6567,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6583,7 +6583,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6608,7 +6608,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6628,7 +6628,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6643,7 +6643,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6654,7 +6654,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -6676,7 +6676,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "bech32",
  "borsh",
@@ -6691,7 +6691,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -6700,7 +6700,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/sp1/guest-celestia/Cargo.toml
+++ b/crates/provers/sp1/guest-celestia/Cargo.toml
@@ -12,16 +12,16 @@ anyhow = { version = "1.0.95" }
 sp1-zkvm = { version = "6.2.1" }
 stf-starter = { path = "../../../stf", default-features = false, features = ["celestia_da"] }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1", optional = true }
 
 [patch.crates-io]
 sha2-v0-9-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.9.9-sp1-6.0.0" }

--- a/crates/provers/sp1/guest-celestia/Cargo.toml
+++ b/crates/provers/sp1/guest-celestia/Cargo.toml
@@ -41,7 +41,6 @@ opt-level = 3
 
 [profile.release]
 debug = 1
-lto = true
 
 [profile.release.build-override]
 opt-level = 3

--- a/crates/provers/sp1/guest-celestia/Cargo.toml
+++ b/crates/provers/sp1/guest-celestia/Cargo.toml
@@ -9,19 +9,19 @@ resolver = "2"
 [dependencies]
 anyhow = { version = "1.0.95" }
 
-sp1-zkvm = { version = "6.2.1" }
+sp1-zkvm = { version = "6.2.2" }
 stf-starter = { path = "../../../stf", default-features = false, features = ["celestia_da"] }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6", optional = true }
 
 [patch.crates-io]
 sha2-v0-9-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.9.9-sp1-6.0.0" }

--- a/crates/provers/sp1/guest-celestia/Cargo.toml
+++ b/crates/provers/sp1/guest-celestia/Cargo.toml
@@ -41,6 +41,7 @@ opt-level = 3
 
 [profile.release]
 debug = 1
+#lto = true
 
 [profile.release.build-override]
 opt-level = 3

--- a/crates/provers/sp1/guest-celestia/Cargo.toml
+++ b/crates/provers/sp1/guest-celestia/Cargo.toml
@@ -8,9 +8,7 @@ resolver = "2"
 
 [dependencies]
 anyhow = { version = "1.0.95" }
-
 sp1-zkvm = { version = "6.2.2" }
-stf-starter = { path = "../../../stf", default-features = false, features = ["celestia_da"] }
 
 sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6", features = ["evm"] }
 sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
@@ -22,6 +20,8 @@ sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev =
 sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
 sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
 sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6", optional = true }
+
+stf-starter = { path = "../../../stf", default-features = false, features = ["celestia_da"] }
 
 [patch.crates-io]
 sha2-v0-9-9 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.9.9-sp1-6.0.0" }

--- a/crates/provers/sp1/guest-mock/Cargo.lock
+++ b/crates/provers/sp1/guest-mock/Cargo.lock
@@ -2573,7 +2573,6 @@ name = "guest-mock-starter-sp1"
 version = "0.3.0"
 dependencies = [
  "anyhow",
- "serde",
  "sov-address",
  "sov-kernels",
  "sov-metrics",

--- a/crates/provers/sp1/guest-mock/Cargo.lock
+++ b/crates/provers/sp1/guest-mock/Cargo.lock
@@ -3468,7 +3468,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 
 [[package]]
 name = "nmt-rs"
@@ -6120,7 +6120,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6134,7 +6134,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6152,7 +6152,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6171,7 +6171,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6190,7 +6190,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6209,7 +6209,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6220,7 +6220,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -6240,7 +6240,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6267,7 +6267,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6283,7 +6283,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "borsh",
  "derivative",
@@ -6297,7 +6297,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6312,7 +6312,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6348,7 +6348,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6369,7 +6369,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -6382,7 +6382,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6395,7 +6395,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6416,7 +6416,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6434,7 +6434,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6464,7 +6464,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6486,7 +6486,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6503,7 +6503,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6516,7 +6516,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6533,7 +6533,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6553,7 +6553,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6568,7 +6568,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6589,7 +6589,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6605,7 +6605,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6630,7 +6630,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6650,7 +6650,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6665,7 +6665,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6676,7 +6676,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -6698,7 +6698,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "bech32",
  "borsh",
@@ -6713,7 +6713,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -6722,7 +6722,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b#0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/sp1/guest-mock/Cargo.lock
+++ b/crates/provers/sp1/guest-mock/Cargo.lock
@@ -3468,7 +3468,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 
 [[package]]
 name = "nmt-rs"
@@ -3767,9 +3767,9 @@ dependencies = [
 
 [[package]]
 name = "p3-air"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a16a8d78c6a37d0eb66b008a18a9e8caa38c3a6a9ca9036416d509faf3dbc86"
+checksum = "d3a5de20a2301bf2530de1ceb13768ec3a80f729fbf8b72f813e30bc54c5bce2"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -3778,9 +3778,9 @@ dependencies = [
 
 [[package]]
 name = "p3-baby-bear"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d80b9c0a27092644dc22fd8fd6768dab62d325c6f7d121cf896e6bb3789779cf"
+checksum = "d69e6e9af4eaaaa60f7bb9f0e0f73ebcbaefe7e00974d97ad0fa542d6a4f0890"
 dependencies = [
  "cfg-if",
  "num-bigint 0.4.6",
@@ -3795,9 +3795,9 @@ dependencies = [
 
 [[package]]
 name = "p3-bn254-fr"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577200e3fa7e49e2b21e940a6dc7399dc63acb8581da088558cdf7c455adafc0"
+checksum = "2077757c7cb514202ccb5368f521f23f5709c720599e6545c683c66e0a52d2d8"
 dependencies = [
  "ff",
  "num-bigint 0.4.6",
@@ -3810,9 +3810,9 @@ dependencies = [
 
 [[package]]
 name = "p3-challenger"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75358edd6e2562752c01f5064a66d88144a3e75ace0407166dbdf8a727597f52"
+checksum = "b6a908924d43e4cfb93fb41c8346cac211b70314385a9037e9241f5b7f3eaf77"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -3824,9 +3824,9 @@ dependencies = [
 
 [[package]]
 name = "p3-commit"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0991de9c2f2f8c6a6667eaebe2a5495a2132f9709ffa93357dc18865d154f16"
+checksum = "50acacc7219fce6c01db938f82c1b21b5e7133990b7fff861f91534aeb569419"
 dependencies = [
  "itertools 0.12.1",
  "p3-challenger",
@@ -3838,9 +3838,9 @@ dependencies = [
 
 [[package]]
 name = "p3-dft"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761f1e1b014f2b1b69bd0309124e233d64aa3590e6a41ee786000dd849506d51"
+checksum = "be6408b10a2c27eb13a7d5580c546c2179a8dc7dbc10a990657311891f9b41c0"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -3851,9 +3851,9 @@ dependencies = [
 
 [[package]]
 name = "p3-field"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df7cebaa4079b24e0dd7e3aad59eebcbb99a67c1271f79ad884a7c032f5f183"
+checksum = "3dc75969ca3ac847f43e632ab979d59ff7a68f9eac8dbf8edcbba47fc2e1d3aa"
 dependencies = [
  "itertools 0.12.1",
  "num-bigint 0.4.6",
@@ -3865,9 +3865,9 @@ dependencies = [
 
 [[package]]
 name = "p3-fri"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ef10c7f829294e16a6248200e9571908177c0b5f35bdd70748ac3239a02d29"
+checksum = "5cbc4965ee488f3247867b7ec4bb005b8afa72cb0d461a4dcb1387ecab6426d5"
 dependencies = [
  "itertools 0.12.1",
  "p3-challenger",
@@ -3884,9 +3884,9 @@ dependencies = [
 
 [[package]]
 name = "p3-interpolation"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413812d3ada8aa10ece23fc68d47d0c23eed1decbc3844a56f9647c7199796d7"
+checksum = "08ad7e9f08c336d7ea39d12e11951188473542565323bac2a6535e536b58487d"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -3895,9 +3895,9 @@ dependencies = [
 
 [[package]]
 name = "p3-keccak-air"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a087526deb74bf12cc4efc1e50d5c387120624b15ea1de1f3efb440efbcd4d"
+checksum = "1f5bf177d56740078b5a5a842fa2393427796283dc8174b4a1a325c2d0b042de"
 dependencies = [
  "p3-air",
  "p3-field",
@@ -3909,9 +3909,9 @@ dependencies = [
 
 [[package]]
 name = "p3-koala-bear"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cea0ba3389b034b6088d566aea8b57aa29dd2e180966e0c8056f61331c92b4e"
+checksum = "3a9683cd0ef68100df7c62490533047bcf19c04c4a0fa1efc9d7c1e03e31f6b3"
 dependencies = [
  "cfg-if",
  "num-bigint 0.4.6",
@@ -3926,9 +3926,9 @@ dependencies = [
 
 [[package]]
 name = "p3-matrix"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fae5cc6ce726cc265cc687c1214e3f1ac1f5c6e973442286ba00d1e75da1c3cb"
+checksum = "75c3f150ceb90e09539413bf481e618d05ee19210b4e467d2902eb82d2e15281"
 dependencies = [
  "itertools 0.12.1",
  "p3-field",
@@ -3941,18 +3941,18 @@ dependencies = [
 
 [[package]]
 name = "p3-maybe-rayon"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac1d2f102cf8c71dba1b449575c99697781fcc028831e83d2245787bd7a650"
+checksum = "e0641952b42da45e1dfa2d4a2a3163e330f944ad9740942f35026c0a71a605f1"
 dependencies = [
  "rayon",
 ]
 
 [[package]]
 name = "p3-mds"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f072643e385d65fb9eb089ee6824b320417f78671a0db748566e057e28b250e"
+checksum = "aa4a5f250e174dcfca5cbeac6ad75713924e7e7320e0a335e3c50b8b1f4fe8ec"
 dependencies = [
  "itertools 0.12.1",
  "p3-dft",
@@ -3965,9 +3965,9 @@ dependencies = [
 
 [[package]]
 name = "p3-merkle-tree"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "946fcfa239847824c9216db8ac731611c7e82171ef51869bc89d985ad46000d0"
+checksum = "d5703d9229d52a8c09970e4d722c3a8b4d37e688c306c3a1c03b872efcd204e6"
 dependencies = [
  "itertools 0.12.1",
  "p3-commit",
@@ -3982,9 +3982,9 @@ dependencies = [
 
 [[package]]
 name = "p3-poseidon2"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00cc4b6e8a439f79541b0910a016da9e6e12a05a24309bbb713e1db0db396952"
+checksum = "522986377b2164c5f94f2dae88e0e0a3d169cc6239202ef4aeb4322d60feffd0"
 dependencies = [
  "gcd",
  "p3-field",
@@ -3996,9 +3996,9 @@ dependencies = [
 
 [[package]]
 name = "p3-symmetric"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eebff7fea7deb08a57ccf731a0ed39df25cc66a0e0c2d92c4472c4dee02ee21"
+checksum = "9047ce85c086a9b3f118e10078f10636f7bfeed5da871a04da0b61400af8793a"
 dependencies = [
  "itertools 0.12.1",
  "p3-field",
@@ -4007,9 +4007,9 @@ dependencies = [
 
 [[package]]
 name = "p3-uni-stark"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e352e1c9765674f618dbd56e33f673a688d1f85332929fcbefa0fc5e5f4373b5"
+checksum = "fc3dfdeba14d8db621c4e52dd63973384ff35f353fd750154ff88397f4ea5adf"
 dependencies = [
  "itertools 0.12.1",
  "p3-air",
@@ -4026,9 +4026,9 @@ dependencies = [
 
 [[package]]
 name = "p3-util"
-version = "0.3.3-succinct"
+version = "0.4.3-succinct"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8164df89bbc92e29938f916cc5f1ccbfe6a36fb5040f21ba93c1f21985b9868"
+checksum = "cff962f8eaa5f36e0447cee7c241f6b4b475fadf3ee61f154327a26bb4e009ba"
 dependencies = [
  "serde",
 ]
@@ -5646,18 +5646,18 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slop-air"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0f533af798f4f9095bbb2a04a91f2026acfc5c5d7578581193bcec71e6a8db"
+checksum = "4aaab798ba2ee1d2fffb3075fc303e4fd87b5b3062693a68f81adb8b508821bd"
 dependencies = [
  "p3-air",
 ]
 
 [[package]]
 name = "slop-algebra"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a473c3a06b466dd0708829415a8a9fab451740da066e07862c8c098904aaad6"
+checksum = "3e8abf7cfad18c0580576e8adc01f7fa27b1cb19432e451e82950c9a445a7cfc"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -5666,9 +5666,9 @@ dependencies = [
 
 [[package]]
 name = "slop-alloc"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69234b7c30707f1ca518d469a014bbc10d38b97e17fef5dbfd158a8269255595"
+checksum = "550acd655362b52fc00d00410f08fc5dea4d22e35eef091c09b6a37d9c79e014"
 dependencies = [
  "serde",
  "slop-algebra",
@@ -5677,9 +5677,9 @@ dependencies = [
 
 [[package]]
 name = "slop-baby-bear"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c830173902ff1d5fcb2fa8f40ef34c7d68685059a99a6b9ef91be4bb252abd"
+checksum = "3263d9487d6e632a747dd267d981e859e4f9fb97506dd8b547049116e0f49dc9"
 dependencies = [
  "lazy_static",
  "p3-baby-bear",
@@ -5692,9 +5692,9 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2dfc41465ee2a8f65afc09da3570997f3c0bf58ae57d559dd7bb05ad5b3f2a0"
+checksum = "596da7b2b980055ec1074c61f7b7f243e57f4fef81ab04f717bcc99b3391191d"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -5715,9 +5715,9 @@ dependencies = [
 
 [[package]]
 name = "slop-basefold-prover"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fe45ae8840223fb6a1bc9cf1d97c91d0017246b168280242d75c6aa4dfb785"
+checksum = "ce348433feab7a98c2d18419c11320a63a9407a7bf360fcb1d12e98610def29d"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -5742,9 +5742,9 @@ dependencies = [
 
 [[package]]
 name = "slop-bn254"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7fbae5dd16a3d1e87c9e99cfd557338171710be01458bd5b12dded3878d3fd8"
+checksum = "c327e0927fabf9c0ae9a7b0333027dc04431e5981ab80d7bbe994d6c4ce35fc1"
 dependencies = [
  "ff",
  "p3-bn254-fr",
@@ -5757,9 +5757,9 @@ dependencies = [
 
 [[package]]
 name = "slop-challenger"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e80df718cef7d3100658dc8b46fafcc994b814421ec9a7d0763a6ee1e5070c"
+checksum = "c263e731bb694d4465eedae7ecd6faf1f277198e751f3c209a1c4186d80d1b6b"
 dependencies = [
  "futures",
  "p3-challenger",
@@ -5770,9 +5770,9 @@ dependencies = [
 
 [[package]]
 name = "slop-commit"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e3b8f111af56f28eb847662fb87fa8caaee53930a13e8ecea9724163259664"
+checksum = "109134f16ae1ea59d333cb28de896bfc8ee383fb575819b6a9f78ba72f46e8ad"
 dependencies = [
  "p3-commit",
  "serde",
@@ -5781,9 +5781,9 @@ dependencies = [
 
 [[package]]
 name = "slop-dft"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29b3439e560ad36f22860c1754e2d6b8715a26dd94fd0acd46a8b07be61add7f"
+checksum = "5bac9e643a07f2138cf5faaae46ae1a16bb359d5224aa3010bbf7b0b794dfd07"
 dependencies = [
  "p3-dft",
  "serde",
@@ -5795,18 +5795,18 @@ dependencies = [
 
 [[package]]
 name = "slop-fri"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "361123ccbbd5faa10edb44c6d76b46053e2f539538a159cd952dd4d5b4606c4b"
+checksum = "407ac1bf5c4b05a4da95c9951bf32307049f3157988e4b22f65915ff58f33173"
 dependencies = [
  "p3-fri",
 ]
 
 [[package]]
 name = "slop-futures"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdae12f26b251c25144bae668d44da582ce12deb86d22ff6ebc10a84b2fc2abf"
+checksum = "ee61e1c5d07006a5221314cfe6f6f77d2168e117081fb13581f8596f7262ddd4"
 dependencies = [
  "crossbeam",
  "futures",
@@ -5819,9 +5819,9 @@ dependencies = [
 
 [[package]]
 name = "slop-jagged"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07d9667c28a67f83e42e40c74711f23c072e731e06e9c9997d2e4924d544ce6"
+checksum = "4d313a73ca824342c6468fd1c63a7e3cde89b7cf456d2f3408843100603eadab"
 dependencies = [
  "derive-where",
  "futures",
@@ -5853,18 +5853,18 @@ dependencies = [
 
 [[package]]
 name = "slop-keccak-air"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13601bdd494e77e2d431ba4f555788caf1dc5e5812df49061fedbc957e1e19e3"
+checksum = "07b7952549a449a95b4a2daa4e1861afbe94c5f22d3c0f36bf42406855f5912f"
 dependencies = [
  "p3-keccak-air",
 ]
 
 [[package]]
 name = "slop-koala-bear"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6586b1c0e66c503e4026a8cb007349fa99c2466957c5b09d18fe658d1391ed8"
+checksum = "0a8cdc74f04d13e738b4628312b16dfec6a2e547bde697c8bdcf556884c6e91f"
 dependencies = [
  "lazy_static",
  "p3-koala-bear",
@@ -5877,27 +5877,27 @@ dependencies = [
 
 [[package]]
 name = "slop-matrix"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44c7beb600f1e47c43c2745711cf412872999b1ce6a44b8fb5683cd0b1a64a2"
+checksum = "57b20e8f35b9ebe60aa9bc0a2b76848bb43c8130f4df85491c5d09f49aa92c45"
 dependencies = [
  "p3-matrix",
 ]
 
 [[package]]
 name = "slop-maybe-rayon"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a2e15a4db7cbc703c203c1ea00d5a889bf3ff9646e8cfd7076ef584ebca441"
+checksum = "ef79faf36b964b0b8423179e29c9c6839fd16d3f9548785b69988a50c1ea617d"
 dependencies = [
  "p3-maybe-rayon",
 ]
 
 [[package]]
 name = "slop-merkle-tree"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3d8df667dc00a44093c22564cfc0140b0ca16e41e6b0be7368822832d71d45"
+checksum = "160e61fa46d477af39d4d1b5737faaee77afe0b4106531ae22b9781686b2888e"
 dependencies = [
  "derive-where",
  "itertools 0.14.0",
@@ -5921,9 +5921,9 @@ dependencies = [
 
 [[package]]
 name = "slop-multilinear"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f33c77ba8c2c516592bc23669b47c38babdd3aed64389e368cc1f2f499f8b75e"
+checksum = "671628cc4119c29685ff484d5eb993ba483cef7915d065c993c55842b4c2f3c9"
 dependencies = [
  "derive-where",
  "futures",
@@ -5942,27 +5942,27 @@ dependencies = [
 
 [[package]]
 name = "slop-poseidon2"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c956b11fff1b8a071fa4ba982dc35e458cff1620dc7b33d9cf22d8df30895f79"
+checksum = "3aedfc3bf87cf2694bd108c039d663c346c7bb807491a7db6701eb9dff5c6e5d"
 dependencies = [
  "p3-poseidon2",
 ]
 
 [[package]]
 name = "slop-primitives"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de169e0ca381847f9efa0db5a54533371c10558d7aaed4cb3b2a9bae24a0fe83"
+checksum = "f30e6e332c3cb103541bed9f5f477b769df1b5fb6076b5e2386569c94b1475dc"
 dependencies = [
  "slop-algebra",
 ]
 
 [[package]]
 name = "slop-stacked"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9103802fef961c064a96457b60da838b2d4aa336b00a89fe3af948d684b8226"
+checksum = "4981970b3ea9620889b558cc859edac2ffaeabc0b444027674cf15dd11e8d433"
 dependencies = [
  "derive-where",
  "futures",
@@ -5983,9 +5983,9 @@ dependencies = [
 
 [[package]]
 name = "slop-sumcheck"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4b3d5051be430c5b47e95f8258221cb40d276fa3461d0239ca3cd96d95f4ccc"
+checksum = "f8a67f4c3d2f73c34032c13b85e22eba69ac8a677481dbbdb3f9942be12eb765"
 dependencies = [
  "futures",
  "itertools 0.14.0",
@@ -6001,18 +6001,18 @@ dependencies = [
 
 [[package]]
 name = "slop-symmetric"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955145ad6e3a1d083a428f9274071cfbb44c3b29013aae9d6c4c29fb7328cfc0"
+checksum = "4cb1de854325a8c36a1bdfee5514e1d4c9f39290ae19eeaecb21ca6ee88d96d6"
 dependencies = [
  "p3-symmetric",
 ]
 
 [[package]]
 name = "slop-tensor"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84835a3d915fb0402eb7b821ba1637399e7f3d330ba8f9b6faca0317d6df7277"
+checksum = "bcf7b2a0e76f1ad8ca43aac248965e4b7448101954661f877a6e6ac7f3813dad"
 dependencies = [
  "arrayvec",
  "derive-where",
@@ -6030,18 +6030,18 @@ dependencies = [
 
 [[package]]
 name = "slop-uni-stark"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd531cc607df2b64e68ea80cc1c05584205b06e70dc5b89563f6b74ab1723f74"
+checksum = "ab33d6a10b1f4dc2edc26131bccd0955ccf5d76e7de6f15c50a9d0873f3f8603"
 dependencies = [
  "p3-uni-stark",
 ]
 
 [[package]]
 name = "slop-utils"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce2c30637af6348960554f9aea4cebce7eb172f173f2187892fcac5cceb3729"
+checksum = "9a9ff3ba185c57a0f4f3bc64e124f5c536d6db416f5f4930c46b278aade270e6"
 dependencies = [
  "p3-util",
  "tracing-forest",
@@ -6050,9 +6050,9 @@ dependencies = [
 
 [[package]]
 name = "slop-whir"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf15dc092785295fe2fd22f1057941a3d5f4d0f6f9ffdce43bb1c9fee8e5578"
+checksum = "07626b0cb8878f3884fa0f68e06ba37746181aa1e7ce0d6e95e53013c5c924e1"
 dependencies = [
  "derive-where",
  "futures",
@@ -6120,7 +6120,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6134,7 +6134,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6152,7 +6152,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6171,7 +6171,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6190,7 +6190,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6209,7 +6209,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6220,7 +6220,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -6240,7 +6240,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6267,7 +6267,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6283,7 +6283,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "borsh",
  "derivative",
@@ -6297,7 +6297,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6312,7 +6312,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6348,7 +6348,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6369,7 +6369,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -6382,7 +6382,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6395,7 +6395,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6416,7 +6416,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6434,7 +6434,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6464,7 +6464,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6486,7 +6486,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6503,7 +6503,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6516,7 +6516,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6533,7 +6533,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6553,7 +6553,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6568,7 +6568,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6589,7 +6589,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6605,7 +6605,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6630,7 +6630,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6650,7 +6650,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6665,7 +6665,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6676,7 +6676,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -6698,7 +6698,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "bech32",
  "borsh",
@@ -6713,7 +6713,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -6722,7 +6722,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=8f3ef59895f34eba876150ab428d41418b3616d1#8f3ef59895f34eba876150ab428d41418b3616d1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -6730,9 +6730,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-build"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "082381d1779d12762a5fb4efa150c2ebdede79a3500eb0a93bf875f7cd64efa0"
+checksum = "69df543394c6d587b0f04a281606a94721d4ea9532866204126a5c0a3a12a45c"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -6744,9 +6744,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61464c74d36b4ab16d44011be6ec1896ee463d9369238ec9edcc1c6ce61f11fd"
+checksum = "ead1f498f7763a3b27740d77db7ef07a737cf568a3c3c85efa72bb1a4858ea6a"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -6785,9 +6785,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52434a8037fd9f19a259f6a432df02fba3ccd2e23ce6a61a50477aba59e04c6e"
+checksum = "14d0e9425daa3f50fcfa9b434e6030b64b3dfacaed3d97fd47314e5ddd851603"
 dependencies = [
  "base64 0.22.1",
  "bincode",
@@ -6807,9 +6807,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-executor-runner-binary"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d79d7911837cf8ef8fcd1fb791f9133914e7067f8bff3e7d6ec6f0ff46cf929b"
+checksum = "6671dac7abe0391d28669cbf6b08806c07feb757c0a5fc29bac8ef6882a642df"
 dependencies = [
  "bincode",
  "crash-handler",
@@ -6822,9 +6822,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-core-machine"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bab240796901b64aa65402d14351b37f8e955438e6ee1861e3c9219bba02691"
+checksum = "7e479b3999aa550b5ef9cadaa950a3ccbfb16ff226c5598fe632a6ee6ea1749d"
 dependencies = [
  "bincode",
  "cfg-if",
@@ -6871,9 +6871,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-curves"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac661914a8708368643c805fbc6aeadba004a0619c2f5f1fbfc1866fd37b5c10"
+checksum = "4376b39a9d40040b826555984b013bd887c4505a354993a27988a6a394155fe7"
 dependencies = [
  "cfg-if",
  "dashu",
@@ -6892,9 +6892,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-derive"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a4f810860abfdc645c4d0589d6efb9302b0d2b3beab8cc60804cb772d5acbe"
+checksum = "fe2bf01a986b185b4497d7386ce3fc35eba3fbeb5169aaa7645b61053c34f449"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6903,9 +6903,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-hypercube"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c2575307ebcd93b4320a06fb48a818669551a64a0fecf3b5666628e15f90e2"
+checksum = "ecb3ffe4a61132c3277e00f85c532fbf38c3a9287ccf10a815339fe5be48af2b"
 dependencies = [
  "arrayref",
  "deepsize2",
@@ -6952,9 +6952,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-jit"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf63168fc46696206b9a8e664283ea630bda7911eb255e1d96391787858c581"
+checksum = "208902ad494f7a101e9c8420f493bc8c42fe4f1f6a3e21b7929d084f3c2e0dce"
 dependencies = [
  "dynasmrt",
  "hashbrown 0.14.5",
@@ -6969,9 +6969,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-lib"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02cd166e010c80e542585bf74585ea80eff117c361656cae43f2968cf0af12d4"
+checksum = "d0d5f56efe1d2a980d0f46083863ef4fdf715ed70cc32668c9e5725af145b8d9"
 dependencies = [
  "bincode",
  "elliptic-curve",
@@ -6981,9 +6981,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-primitives"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df14efe799ebd675cf530c853153a4787327a2385067716dfad4ede79ff31ad"
+checksum = "13ad00052921b993af682403b378c8fe23c40382f9790f093c8fac0f30433c5e"
 dependencies = [
  "bincode",
  "blake3",
@@ -7005,9 +7005,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf089b2fc3cacd5040e6eaeec7d96dc97bfd428421492a0be939f72d48a49851"
+checksum = "3ba6d960746f9a6038834893dc5c774812c004fd846fcbf5dc00f1ea294c02ef"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7069,9 +7069,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-prover-types"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e29236cc1217ab04fdc548dbc83c817ecbf78c348879f5dbe65649680cd2ce89"
+checksum = "ff77aba505e762effc5de8258195f11279471fa9e8a3b0815aa251be22770fd3"
 dependencies = [
  "anyhow",
  "async-scoped",
@@ -7093,9 +7093,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-circuit"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c809d2ff42f22ebeafac078f7fae717e50f9658bcd1a5e847c0c7d7d7bf94019"
+checksum = "bfe43147fe2a5604b1c14d10f44cb7d4304127275470f676b03593a2a00da4f2"
 dependencies = [
  "bincode",
  "itertools 0.14.0",
@@ -7133,9 +7133,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-compiler"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9162e3ad6f369307142a81d627c4883316f7d65b1e5a0ece3dd45780e29ea2"
+checksum = "95f8488f5a4bd212f2498a8363d0f76378328aea5cbe69658c636016797c72ab"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -7154,9 +7154,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-executor"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec793f4c6c032d141476c97fb83dd86abfe3c68f8aace603d57a3d20859a10c5"
+checksum = "ef824f774b7ffac1c3c4f58fe145e4b503ba30ef885993947d4186a448748a7c"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -7178,9 +7178,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-gnark-ffi"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac3939b80a23bc369c2ffc1fdb136de3fd83323fe53b03b17fbb11ea383f330"
+checksum = "e6961ae41bdca71e213d01aad4a7f664d0c95a760975a12816b2ac2d54e1e570"
 dependencies = [
  "anyhow",
  "bincode",
@@ -7202,9 +7202,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-recursion-machine"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e60fd9a5f5b9bc39e3ddb39c5ac49da32b6aa7ab63c4fef7b6bb2565c2e98b9e"
+checksum = "d741527465de17de5c3ef4f9465e77117d2a15599398f97e8fb0cf8c3e57b2f4"
 dependencies = [
  "itertools 0.14.0",
  "rand 0.8.6",
@@ -7224,9 +7224,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-sdk"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c15071380f43c33b3dbe5650cd5acf54a8e0af4b80a833075a56309256a383"
+checksum = "a6af1816d3855a02b002a8be12a3c1856948e45bd5e04d24316aea08717c7405"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7261,9 +7261,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-verifier"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91895b72db38423e477635cf22d65a3dc9dc333a872fc2fe0cd6e8daf9661891"
+checksum = "04eea9c69efabee3fff3c24f2946963d04b62af7fdd7fc6da06b1d4853f8aca6"
 dependencies = [
  "bincode",
  "blake3",
@@ -7288,9 +7288,9 @@ dependencies = [
 
 [[package]]
 name = "sp1-zkvm"
-version = "6.2.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa10f689c4384daf7ece04176c727e6f2e56193e10a406406aa7c9c6c8f8f478"
+checksum = "fb5732e5c4cf9e607f224a0b1a0fd90515897f731eaba33939bf9d5dcdecf4f8"
 dependencies = [
  "cfg-if",
  "critical-section",

--- a/crates/provers/sp1/guest-mock/Cargo.toml
+++ b/crates/provers/sp1/guest-mock/Cargo.toml
@@ -8,18 +8,18 @@ resolver = "2"
 
 [dependencies]
 anyhow = { version = "1.0.95" }
-sp1-zkvm = { version = "6.2.1" }
+sp1-zkvm = { version = "6.2.2" }
 serde = { version = "1.0.188", features = ["derive", "rc"] }
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["mock_da"] }
 

--- a/crates/provers/sp1/guest-mock/Cargo.toml
+++ b/crates/provers/sp1/guest-mock/Cargo.toml
@@ -1,15 +1,15 @@
-[workspace]
-
 [package]
 name = "guest-mock-starter-sp1"
 version = "0.3.0"
 edition = "2021"
 resolver = "2"
 
+[workspace]
+
 [dependencies]
 anyhow = { version = "1.0.95" }
 sp1-zkvm = { version = "6.2.2" }
-serde = { version = "1.0.188", features = ["derive", "rc"] }
+
 sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6", features = ["evm"] }
 sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
 sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
@@ -47,4 +47,10 @@ lto = true
 opt-level = 3
 
 [features]
-bench = ["sov-modules-api/bench", "sov-state/bench", "sov-modules-stf-blueprint/bench", "sov-metrics/sp1", "stf-starter/bench"]
+bench = [
+    "sov-modules-api/bench",
+    "sov-state/bench",
+    "sov-modules-stf-blueprint/bench",
+    "sov-metrics/sp1",
+    "stf-starter/bench"
+]

--- a/crates/provers/sp1/guest-mock/Cargo.toml
+++ b/crates/provers/sp1/guest-mock/Cargo.toml
@@ -10,16 +10,16 @@ resolver = "2"
 anyhow = { version = "1.0.95" }
 sp1-zkvm = { version = "6.2.1" }
 serde = { version = "1.0.188", features = ["derive", "rc"] }
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "0f9e6d5d22ac928cf40c55fbfef90f89c2fc812b", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "8f3ef59895f34eba876150ab428d41418b3616d1", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["mock_da"] }
 

--- a/crates/stf/src/runtime.rs
+++ b/crates/stf/src/runtime.rs
@@ -104,19 +104,4 @@ where
             EvmAndEip712AuthenticatorInput::Standard(call) => call,
         }
     }
-
-    #[cfg(feature = "native")]
-    fn populate_pinned_cache(storage: &S::Storage) -> Option<sov_state::pinned_cache::PinnedCache> {
-        let buckets_and_limits =
-            sov_evm::Evm::<S>::default().get_pinned_cache_buckets_and_limits()?;
-        let mut pinned_cache = sov_state::pinned_cache::PinnedCache::default();
-        for (bucket_id, limit) in buckets_and_limits {
-            if let Err(e) =
-                pinned_cache.try_load_bucket_if_absent(bucket_id.clone(), storage, limit)
-            {
-                tracing::warn!(bucket_id = ?bucket_id, limit = ?limit, error = ?e, "EVM Failed to load bucket into pinned cache");
-            }
-        }
-        Some(pinned_cache)
-    }
 }

--- a/scripts/acceptance-test/constants.testing.toml
+++ b/scripts/acceptance-test/constants.testing.toml
@@ -22,7 +22,7 @@ CHAIN_NAME = "TestChain"
 # The optional `grace_period` field (defaults to 0) specifies how many blocks after end_height
 # the old hash will still be accepted alongside the new hash, allowing for smooth transitions.
 # Example: CHAIN_HASH_OVERRIDES = [{ start_height = 0, end_height = 1000, chain_hash = "0xabc...32_bytes_hex", grace_period = 100 }]
-CHAIN_HASH_OVERRIDES = [{ start_height = 0, end_height = 1011, chain_hash = "3031bcf130d4e706665e7f8a03217d6209551d7e40596622d9214f9d340a4eeb", grace_period = 0 }]
+CHAIN_HASH_OVERRIDES = []
 
 # The namespace used by the rollup to store its data.
 # Using byte_string to convert to ASCII bytes

--- a/scripts/acceptance-test/src/evm_soak.rs
+++ b/scripts/acceptance-test/src/evm_soak.rs
@@ -1,6 +1,5 @@
 use crate::evm_contracts::StateConsistencyTester;
 use crate::{Directories, API_ADDR};
-use alloy::signers::local::PrivateKeySigner;
 use alloy_primitives::{Address, Bytes, U256};
 use alloy_rpc_types::TransactionRequest;
 use alloy_sol_types::SolCall;
@@ -29,7 +28,6 @@ const PRIVILEGED_DEPLOYER_KEY: &str =
 const UNPRIVILEGED_DEPLOYER_OFFSET: u8 = 1;
 const PINNED_WORKER_KEY_OFFSET: u8 = 10;
 const UNPINNED_WORKER_KEY_OFFSET: u8 = 60;
-const DEFAULT_BUCKET_SIZE_LIMIT: usize = 100 * 1024 * 1024;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct StateConsistencyMetadata {
@@ -37,27 +35,10 @@ struct StateConsistencyMetadata {
     unpinned_addresses: Vec<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 struct EvmPinnedCacheConfig {
     #[serde(default)]
     preferred_sequencer_publish_reverted_txs: bool,
-    #[serde(default = "default_bucket_size_limit")]
-    default_bucket_size_limit: usize,
-    #[serde(default)]
-    privileged_deployer_addresses: Vec<Address>,
-    #[serde(default)]
-    known_contracts_and_limits: std::collections::BTreeMap<Address, usize>,
-}
-
-impl Default for EvmPinnedCacheConfig {
-    fn default() -> Self {
-        Self {
-            preferred_sequencer_publish_reverted_txs: false,
-            default_bucket_size_limit: default_bucket_size_limit(),
-            privileged_deployer_addresses: Vec::new(),
-            known_contracts_and_limits: std::collections::BTreeMap::new(),
-        }
-    }
 }
 
 fn evm_rpc_addr() -> SocketAddr {
@@ -76,21 +57,12 @@ fn state_consistency_metadata_path(directories: &Directories) -> PathBuf {
     evm_artifacts_dir(directories).join(STATE_CONSISTENCY_METADATA)
 }
 
-fn default_bucket_size_limit() -> usize {
-    DEFAULT_BUCKET_SIZE_LIMIT
-}
-
 fn derive_worker_key(root_key: &str, worker_idx: u8) -> anyhow::Result<String> {
     let mut key_bytes: [u8; 32] = hex::decode(root_key)?
         .try_into()
         .map_err(|_| anyhow!("Invalid private key length"))?;
     key_bytes[0] = key_bytes[0].wrapping_add(worker_idx);
     Ok(hex::encode(key_bytes))
-}
-
-fn privileged_deployer_address() -> anyhow::Result<Address> {
-    let signer: PrivateKeySigner = PRIVILEGED_DEPLOYER_KEY.parse()?;
-    Ok(signer.address())
 }
 
 pub fn privileged_deployer_key() -> &'static str {
@@ -233,24 +205,13 @@ pub fn load_state_consistency_contracts(
 
 pub fn ensure_evm_pinned_cache_config(directories: &Directories) -> anyhow::Result<()> {
     let config_path = evm_pinned_cache_path(directories);
-    let mut config = if config_path.exists() {
+    let config = if config_path.exists() {
         let raw = fs::read_to_string(&config_path)
             .with_context(|| format!("Failed to read {}", config_path.display()))?;
         serde_json::from_str::<EvmPinnedCacheConfig>(&raw)?
     } else {
         EvmPinnedCacheConfig::default()
     };
-
-    let privileged_address = privileged_deployer_address()?;
-    if !config
-        .privileged_deployer_addresses
-        .iter()
-        .any(|addr| addr == &privileged_address)
-    {
-        config
-            .privileged_deployer_addresses
-            .push(privileged_address);
-    }
 
     fs::write(config_path, serde_json::to_string_pretty(&config)?)?;
     Ok(())


### PR DESCRIPTION
Upgrading to latest dev on 2026-05-26 8f3ef59895f34eba876150ab428d41418b3616d1

Breaking change resolved:
- #2882 (Remove EVM pinned cache): the `populate_pinned_cache` method was dropped from the SDK `Runtime` trait and `EvmExecutionConfig` was flattened to its single remaining field. Removed the `populate_pinned_cache` override in crates/stf/src/runtime.rs, and trimmed the EVM execution config files (configs/{mock,celestia}/evm_pinned_cache.json) to only `preferred_sequencer_publish_reverted_txs`, dropping default_bucket_size_limit, privileged_deployer_addresses, and known_contracts_and_limits. Trimmed the acceptance-test soak config (EvmPinnedCacheConfig) to match.

Non-breaking for the starter: #2909 (sov-state accessory clone reduction; StateCheckpoint::new is not used directly here) and #2915 (EVM subscription test tweak).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/rollup-starter/pull/178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->