### PR TITLE
Acceptance test fixups

### DIFF
--- a/scripts/acceptance-test/src/bin/setup.rs
+++ b/scripts/acceptance-test/src/bin/setup.rs
@@ -9,6 +9,7 @@ use acceptance_test::{
     CommonArgs, Directories, PostgresContainerGuard, ResolvedRunSettings, Runtime,
     ShutdownReceiver, SoakRunOptions, Spec, ThroughputReport, API_URL, SETUP_THROUGHPUT_FILE,
 };
+use anyhow::Context;
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
 use clap::Parser;
@@ -67,13 +68,28 @@ fn should_overwrite_throughput(
                     false
                 }
             }
-            Err(_) => {
-                warn!("Existing throughput file is invalid, overwriting");
+            Err(err) => {
+                warn!(
+                    "Existing throughput file at {} is invalid, overwriting: {}",
+                    throughput_path.display(),
+                    err
+                );
                 true
             }
         },
-        Err(_) => {
-            info!("No existing throughput file, creating new one");
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            info!(
+                "No existing throughput file at {}, creating new one",
+                throughput_path.display()
+            );
+            true
+        }
+        Err(err) => {
+            warn!(
+                "Failed to read existing throughput file at {}, overwriting: {}",
+                throughput_path.display(),
+                err
+            );
             true
         }
     }
@@ -210,7 +226,13 @@ async fn run_setup(
         Ok(throughput_report) => {
             let throughput_path = directories.throughput_dir.join(SETUP_THROUGHPUT_FILE);
             if should_overwrite_throughput(&throughput_path, &throughput_report) {
-                std::fs::write(&throughput_path, serde_json::to_string(&throughput_report)?)?;
+                std::fs::write(&throughput_path, serde_json::to_string(&throughput_report)?)
+                    .with_context(|| {
+                        format!(
+                            "failed to write setup throughput baseline {}",
+                            throughput_path.display()
+                        )
+                    })?;
             }
             save_mock_data(directories.clone())?;
             if settings.cleanup_rollup_state_on_success() {
@@ -407,21 +429,28 @@ fn save_mock_data(directories: Directories) -> Result<(), anyhow::Error> {
     for input in ["mock_da.sqlite", "mock_da.sqlite-shm", "mock_da.sqlite-wal"] {
         let mut target = "persistent_".to_string();
         target.push_str(input);
-        if let Err(err) = std::fs::rename(
-            directories.output_dir.join(input),
-            directories.output_dir.join(target),
-        ) {
+        let input_path = directories.output_dir.join(input);
+        let target_path = directories.output_dir.join(target);
+        if let Err(err) = std::fs::rename(&input_path, &target_path) {
             if input == "mock_da.sqlite" {
                 tracing::error!(
-                    "Failed to rename {} for persistence accross runs: {}",
-                    input,
+                    "Failed to rename {} to {} for persistence across runs: {}",
+                    input_path.display(),
+                    target_path.display(),
                     err
                 );
-                return Err(anyhow::anyhow!("Failed to rename {}: {}", input, err));
+                return Err(err).with_context(|| {
+                    format!(
+                        "failed to rename mock DA database from {} to {} for persistence across runs",
+                        input_path.display(),
+                        target_path.display()
+                    )
+                });
             } else {
                 tracing::warn!(
-                    "Failed to rename {} for persistence accross runs: {}. Ignoring.",
-                    input,
+                    "Failed to rename {} to {} for persistence across runs: {}. Ignoring.",
+                    input_path.display(),
+                    target_path.display(),
                     err
                 );
             }

--- a/scripts/acceptance-test/src/config.rs
+++ b/scripts/acceptance-test/src/config.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, bail};
+use anyhow::{anyhow, bail, Context};
 use clap::{Args, ValueEnum};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -123,10 +123,22 @@ pub fn prepare_rollup_state_dir(
             }
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            fs::create_dir_all(path)?;
+            fs::create_dir_all(path).with_context(|| {
+                format!(
+                    "failed to create missing rollup state directory {}",
+                    path.display()
+                )
+            })?;
             return Ok(());
         }
-        Err(e) => return Err(e.into()),
+        Err(e) => {
+            return Err(e).with_context(|| {
+                format!(
+                    "failed to inspect rollup state directory {}",
+                    path.display()
+                )
+            });
+        }
     }
 
     match policy {
@@ -135,7 +147,8 @@ pub fn prepare_rollup_state_dir(
         ExistingRollupState::Ignore => {}
     }
 
-    fs::create_dir_all(path)?;
+    fs::create_dir_all(path)
+        .with_context(|| format!("failed to create rollup state directory {}", path.display()))?;
     Ok(())
 }
 
@@ -150,27 +163,47 @@ pub fn cleanup_rollup_state_dir(path: &Path) -> Result<(), anyhow::Error> {
             }
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-        Err(e) => return Err(e.into()),
+        Err(e) => {
+            return Err(e).with_context(|| {
+                format!(
+                    "failed to inspect rollup state directory {}",
+                    path.display()
+                )
+            });
+        }
     }
 
     clear_directory(path)
 }
 
 fn clear_directory(path: &Path) -> Result<(), anyhow::Error> {
-    for entry in fs::read_dir(path)? {
-        let entry = entry?;
+    for entry in fs::read_dir(path)
+        .with_context(|| format!("failed to read directory {}", path.display()))?
+    {
+        let entry = entry
+            .with_context(|| format!("failed to read entry in directory {}", path.display()))?;
         let entry_path = entry.path();
-        if entry.file_type()?.is_dir() {
-            fs::remove_dir_all(&entry_path)?;
+        if entry
+            .file_type()
+            .with_context(|| format!("failed to inspect directory entry {}", entry_path.display()))?
+            .is_dir()
+        {
+            fs::remove_dir_all(&entry_path)
+                .with_context(|| format!("failed to remove directory {}", entry_path.display()))?;
         } else {
-            fs::remove_file(&entry_path)?;
+            fs::remove_file(&entry_path)
+                .with_context(|| format!("failed to remove file {}", entry_path.display()))?;
         }
     }
     Ok(())
 }
 
 fn ensure_directory_empty(path: &Path) -> Result<(), anyhow::Error> {
-    if fs::read_dir(path)?.next().is_some() {
+    if let Some(entry) = fs::read_dir(path)
+        .with_context(|| format!("failed to read rollup state directory {}", path.display()))?
+        .next()
+    {
+        entry.with_context(|| format!("failed to read entry in directory {}", path.display()))?;
         return Err(anyhow!(
             "Rollup state directory {} is not empty. Re-run with --on-existing-rollup-state=clobber or --on-existing-rollup-state=ignore to proceed.",
             path.display()

--- a/scripts/acceptance-test/src/evm_soak.rs
+++ b/scripts/acceptance-test/src/evm_soak.rs
@@ -161,12 +161,21 @@ fn write_state_consistency_metadata(
             .collect(),
     };
     let metadata_path = state_consistency_metadata_path(directories);
-    fs::create_dir_all(
-        metadata_path
-            .parent()
-            .ok_or_else(|| anyhow!("Invalid metadata path"))?,
-    )?;
-    fs::write(metadata_path, serde_json::to_string_pretty(&metadata)?)?;
+    let metadata_parent = metadata_path
+        .parent()
+        .ok_or_else(|| anyhow!("Invalid metadata path"))?;
+    fs::create_dir_all(metadata_parent).with_context(|| {
+        format!(
+            "failed to create EVM metadata directory {}",
+            metadata_parent.display()
+        )
+    })?;
+    fs::write(&metadata_path, serde_json::to_string_pretty(&metadata)?).with_context(|| {
+        format!(
+            "failed to write EVM state consistency metadata {}",
+            metadata_path.display()
+        )
+    })?;
     Ok(())
 }
 
@@ -179,9 +188,18 @@ pub fn load_state_consistency_contracts(
     directories: &Directories,
 ) -> anyhow::Result<StateConsistencyContracts> {
     let metadata_path = state_consistency_metadata_path(directories);
-    let raw = fs::read_to_string(&metadata_path)
-        .with_context(|| format!("Missing {}", metadata_path.display()))?;
-    let metadata: StateConsistencyMetadata = serde_json::from_str(&raw)?;
+    let raw = fs::read_to_string(&metadata_path).with_context(|| {
+        format!(
+            "failed to read EVM state consistency metadata {}. Run `setup` with the same profile first",
+            metadata_path.display()
+        )
+    })?;
+    let metadata: StateConsistencyMetadata = serde_json::from_str(&raw).with_context(|| {
+        format!(
+            "failed to parse EVM state consistency metadata {}",
+            metadata_path.display()
+        )
+    })?;
     let pinned = metadata
         .pinned_addresses
         .iter()
@@ -208,12 +226,22 @@ pub fn ensure_evm_pinned_cache_config(directories: &Directories) -> anyhow::Resu
     let config = if config_path.exists() {
         let raw = fs::read_to_string(&config_path)
             .with_context(|| format!("Failed to read {}", config_path.display()))?;
-        serde_json::from_str::<EvmPinnedCacheConfig>(&raw)?
+        serde_json::from_str::<EvmPinnedCacheConfig>(&raw).with_context(|| {
+            format!(
+                "failed to parse EVM pinned cache config {}",
+                config_path.display()
+            )
+        })?
     } else {
         EvmPinnedCacheConfig::default()
     };
 
-    fs::write(config_path, serde_json::to_string_pretty(&config)?)?;
+    fs::write(&config_path, serde_json::to_string_pretty(&config)?).with_context(|| {
+        format!(
+            "failed to write EVM pinned cache config {}",
+            config_path.display()
+        )
+    })?;
     Ok(())
 }
 

--- a/scripts/acceptance-test/src/fetch_and_compare.rs
+++ b/scripts/acceptance-test/src/fetch_and_compare.rs
@@ -1,5 +1,6 @@
 use sov_api_spec::types::{self, GetBatchByIdChildren, GetSlotByIdChildren, LedgerBatch, Slot};
 
+use anyhow::Context;
 use futures::stream::BoxStream;
 use serde_json::Value;
 use sov_rollup_interface::node::ledger_api::IncludeChildren;
@@ -98,7 +99,8 @@ pub fn save_slot_snapshot(slot: &Slot, output_dir: &Path) -> Result<(), anyhow::
     let filename = format!("slot_{:04}_with_children.json", slot.number);
     let filepath = output_dir.join(&filename);
 
-    std::fs::write(&filepath, snapshot_json)?;
+    std::fs::write(&filepath, snapshot_json)
+        .with_context(|| format!("failed to write slot snapshot {}", filepath.display()))?;
 
     Ok(())
 }

--- a/scripts/acceptance-test/src/lib.rs
+++ b/scripts/acceptance-test/src/lib.rs
@@ -279,7 +279,7 @@ pub struct Directories {
 
 impl Directories {
     pub fn from_settings(settings: &ResolvedRunSettings) -> Result<Self, anyhow::Error> {
-        let cwd = std::env::current_dir()?;
+        let cwd = std::env::current_dir().context("failed to read current working directory")?;
         let acceptance_test_dir = env::var("CARGO_MANIFEST_DIR")
             .map(PathBuf::from)
             .unwrap_or_else(|_| PathBuf::from("."));
@@ -290,7 +290,7 @@ impl Directories {
         settings: &ResolvedRunSettings,
         acceptance_test_dir: PathBuf,
     ) -> Result<Self, anyhow::Error> {
-        let cwd = std::env::current_dir()?;
+        let cwd = std::env::current_dir().context("failed to read current working directory")?;
         Self::from_settings_with_acceptance_dir_and_cwd(settings, acceptance_test_dir, cwd)
     }
 
@@ -324,7 +324,12 @@ impl Directories {
         } else {
             acceptance_test_dir.join("rollup-build-cache")
         };
-        fs::create_dir_all(&rollup_build_cache_dir)?;
+        fs::create_dir_all(&rollup_build_cache_dir).with_context(|| {
+            format!(
+                "failed to create rollup build cache directory {}",
+                rollup_build_cache_dir.display()
+            )
+        })?;
         let manager_build_dir = acceptance_test_dir.join("rollup-manager-build");
 
         let output_root = if let Some(path) = settings.acceptance_data_dir.clone() {
@@ -333,14 +338,24 @@ impl Directories {
             acceptance_test_dir.join("acceptance-test-data")
         };
         let output_dir = output_root.join(settings.profile.subdir());
-        fs::create_dir_all(&output_dir)?;
+        fs::create_dir_all(&output_dir).with_context(|| {
+            format!(
+                "failed to create acceptance test data directory {}",
+                output_dir.display()
+            )
+        })?;
         let rollup_data_path = if let Some(path) = settings.rollup_state_dir.clone() {
             absolutize_from_cwd(path, &cwd)
         } else {
             output_dir.join("rollup-starter-data")
         };
         let snapshots_dir = output_dir.join("snapshots");
-        fs::create_dir_all(&snapshots_dir)?;
+        fs::create_dir_all(&snapshots_dir).with_context(|| {
+            format!(
+                "failed to create acceptance snapshot directory {}",
+                snapshots_dir.display()
+            )
+        })?;
 
         let throughput_root = if let Some(path) = settings.acceptance_throughput_dir.clone() {
             absolutize_from_cwd(path, &cwd)
@@ -348,7 +363,12 @@ impl Directories {
             acceptance_test_dir.join("acceptance-throughput")
         };
         let throughput_dir = throughput_root.join(settings.profile.subdir());
-        fs::create_dir_all(&throughput_dir)?;
+        fs::create_dir_all(&throughput_dir).with_context(|| {
+            format!(
+                "failed to create acceptance throughput directory {}",
+                throughput_dir.display()
+            )
+        })?;
 
         Ok(Self {
             rollup_root,

--- a/scripts/acceptance-test/src/main.rs
+++ b/scripts/acceptance-test/src/main.rs
@@ -6,7 +6,7 @@ use acceptance_test::{
     prepare_rollup_state_dir, run_soak, run_until_shutdown_signal, shutdown_error,
     sleep_or_shutdown, spawn_rollup_manager, wait_for_shutdown, write_manager_config,
     AcceptanceRunPlan, CommonArgs, Directories, LocalConstantsManifest, PostgresContainerGuard,
-    ResolvedRunSettings, ShutdownReceiver, SoakRunOptions, API_URL,
+    ResolvedRunSettings, RunProfile, ShutdownReceiver, SoakRunOptions, API_URL,
 };
 use acceptance_test::{wait_for_sequencer_ready, ThroughputReport, SETUP_THROUGHPUT_FILE};
 use anyhow::Context;
@@ -288,8 +288,15 @@ async fn run_test(
             )?;
         let previous_throughput = previous_throughput_report.throughput();
         let new_throughput = new_throughput_report.throughput();
-        if new_throughput < (previous_throughput * 0.9) {
-            anyhow::bail!("Throughput is less than 90% of the previous throughput. This is likely due to a bug in the rollup. Old throughput: {:.2} txs/slot, new throughput: {:.2} txs/slot", previous_throughput, new_throughput);
+        let min_throughput_ratio = throughput_regression_min_ratio(settings.profile);
+        if new_throughput < (previous_throughput * min_throughput_ratio) {
+            anyhow::bail!(
+                "Throughput is less than {:.0}% of the previous throughput for the {:?} profile. This is likely due to a bug in the rollup. Old throughput: {:.2} txs/slot, new throughput: {:.2} txs/slot",
+                min_throughput_ratio * 100.0,
+                settings.profile,
+                previous_throughput,
+                new_throughput
+            );
         }
     }
 
@@ -322,6 +329,13 @@ fn throughput_check_enabled(args: &Args) -> bool {
     !args.no_throughput_check
 }
 
+fn throughput_regression_min_ratio(profile: RunProfile) -> f64 {
+    match profile {
+        RunProfile::Full => 0.9,
+        RunProfile::Short => 0.7,
+    }
+}
+
 #[derive(Parser, Debug)]
 struct Args {
     #[command(flatten)]
@@ -348,5 +362,15 @@ mod tests {
         let args = Args::try_parse_from(["acceptance-test", "--no-throughput-check"]).unwrap();
 
         assert!(!throughput_check_enabled(&args));
+    }
+
+    #[test]
+    fn full_profile_uses_strict_throughput_threshold() {
+        assert_eq!(throughput_regression_min_ratio(RunProfile::Full), 0.9);
+    }
+
+    #[test]
+    fn short_profile_uses_lenient_throughput_threshold() {
+        assert_eq!(throughput_regression_min_ratio(RunProfile::Short), 0.7);
     }
 }

--- a/scripts/acceptance-test/src/main.rs
+++ b/scripts/acceptance-test/src/main.rs
@@ -9,6 +9,7 @@ use acceptance_test::{
     ResolvedRunSettings, ShutdownReceiver, SoakRunOptions, API_URL,
 };
 use acceptance_test::{wait_for_sequencer_ready, ThroughputReport, SETUP_THROUGHPUT_FILE};
+use anyhow::Context;
 use chrono::Utc;
 use clap::Parser;
 use sov_api_spec::types::{self, GetSlotByIdChildren, Slot};
@@ -60,29 +61,52 @@ fn copy_persistent_mock_data(directories: &Directories) -> Result<(), anyhow::Er
     tracing::info!("Copying persistent mock data back to mock_da.sqlite");
     // Clean up any files from any previous runs. This is needed particularly for the shm and wal
     // files since they may not get overwritten by a copy, but we do all three for consistency.
-    std::fs::remove_file(directories.output_dir.join("mock_da.sqlite"))
-        .or_else(ignore_file_not_found)?;
-    std::fs::remove_file(directories.output_dir.join("mock_da.sqlite-shm"))
-        .or_else(ignore_file_not_found)?;
-    std::fs::remove_file(directories.output_dir.join("mock_da.sqlite-wal"))
-        .or_else(ignore_file_not_found)?;
+    for stale_file in [
+        directories.output_dir.join("mock_da.sqlite"),
+        directories.output_dir.join("mock_da.sqlite-shm"),
+        directories.output_dir.join("mock_da.sqlite-wal"),
+    ] {
+        std::fs::remove_file(&stale_file)
+            .or_else(ignore_file_not_found)
+            .with_context(|| {
+                format!(
+                    "failed to remove stale mock DA file {}",
+                    stale_file.display()
+                )
+            })?;
+    }
 
     // Then copy the base file, always
-    std::fs::copy(
-        directories.output_dir.join("persistent_mock_da.sqlite"),
-        directories.output_dir.join("mock_da.sqlite"),
-    )?;
+    let persistent_mock_da = directories.output_dir.join("persistent_mock_da.sqlite");
+    let mock_da = directories.output_dir.join("mock_da.sqlite");
+    std::fs::copy(&persistent_mock_da, &mock_da).with_context(|| {
+        format!(
+            "failed to copy persistent mock DA database from {} to {}",
+            persistent_mock_da.display(),
+            mock_da.display()
+        )
+    })?;
     // And the dangling wal and shm only if they exist
-    std::fs::copy(
-        directories.output_dir.join("persistent_mock_da.sqlite-shm"),
-        directories.output_dir.join("mock_da.sqlite-shm"),
-    )
-    .or_else(ignore_file_not_found)?;
-    std::fs::copy(
-        directories.output_dir.join("persistent_mock_da.sqlite-wal"),
-        directories.output_dir.join("mock_da.sqlite-wal"),
-    )
-    .or_else(ignore_file_not_found)?;
+    for (persistent_sidecar, mock_da_sidecar) in [
+        (
+            directories.output_dir.join("persistent_mock_da.sqlite-shm"),
+            directories.output_dir.join("mock_da.sqlite-shm"),
+        ),
+        (
+            directories.output_dir.join("persistent_mock_da.sqlite-wal"),
+            directories.output_dir.join("mock_da.sqlite-wal"),
+        ),
+    ] {
+        std::fs::copy(&persistent_sidecar, &mock_da_sidecar)
+            .or_else(ignore_file_not_found)
+            .with_context(|| {
+                format!(
+                    "failed to copy persistent mock DA sidecar from {} to {}",
+                    persistent_sidecar.display(),
+                    mock_da_sidecar.display()
+                )
+            })?;
+    }
 
     tracing::info!("Persistent mock data copied back to mock_da.sqlite");
     Ok(())
@@ -245,9 +269,23 @@ async fn run_test(
     )
     .await?;
     if throughput_check {
-        let previous_throughput_report: ThroughputReport = serde_json::from_str::<ThroughputReport>(
-            &std::fs::read_to_string(directories.throughput_dir.join(SETUP_THROUGHPUT_FILE))?,
-        )?;
+        let throughput_baseline_path = directories.throughput_dir.join(SETUP_THROUGHPUT_FILE);
+        let previous_throughput_contents =
+            std::fs::read_to_string(&throughput_baseline_path).with_context(|| {
+                format!(
+                    "failed to read setup throughput baseline at {}. Run `setup` with the same profile or pass `--no-throughput-check`",
+                    throughput_baseline_path.display()
+                )
+            })?;
+        let previous_throughput_report: ThroughputReport =
+            serde_json::from_str::<ThroughputReport>(&previous_throughput_contents).with_context(
+                || {
+                    format!(
+                        "failed to parse setup throughput baseline {}",
+                        throughput_baseline_path.display()
+                    )
+                },
+            )?;
         let previous_throughput = previous_throughput_report.throughput();
         let new_throughput = new_throughput_report.throughput();
         if new_throughput < (previous_throughput * 0.9) {
@@ -258,10 +296,17 @@ async fn run_test(
     // Save throughput report with timestamp to keep a record of test runs
     let timestamp = Utc::now().format("%Y%m%d_%H%M%S");
     let throughput_filename = format!("test_throughput_{}.json", timestamp);
+    let throughput_path = directories.throughput_dir.join(&throughput_filename);
     std::fs::write(
-        directories.throughput_dir.join(&throughput_filename),
+        &throughput_path,
         serde_json::to_string(&new_throughput_report)?,
-    )?;
+    )
+    .with_context(|| {
+        format!(
+            "failed to write throughput report {}",
+            throughput_path.display()
+        )
+    })?;
     info!("Saved throughput report to {}", throughput_filename);
     if settings.cleanup_rollup_state_on_success() {
         cleanup_rollup_state_dir(&directories.rollup_data_path)?;

--- a/scripts/acceptance-test/src/versioned_setup.rs
+++ b/scripts/acceptance-test/src/versioned_setup.rs
@@ -343,12 +343,12 @@ fn build_rollup_manager_binary(manager_build_root: &Path) -> Result<PathBuf, any
             manager_bin.display()
         ));
     }
-    Ok(manager_bin.canonicalize().with_context(|| {
+    manager_bin.canonicalize().with_context(|| {
         format!(
             "failed to canonicalize built manager binary {}",
             manager_bin.display()
         )
-    })?)
+    })
 }
 
 pub fn prepare_acceptance_run_plan(

--- a/scripts/acceptance-test/src/versioned_setup.rs
+++ b/scripts/acceptance-test/src/versioned_setup.rs
@@ -119,8 +119,10 @@ fn load_version_sources(directories: &Directories) -> anyhow::Result<Vec<Resolve
         }]);
     }
 
-    let spec_contents = fs::read_to_string(&spec_path)?;
-    let spec: VersionSpecRoot = serde_yaml::from_str(&spec_contents)?;
+    let spec_contents = fs::read_to_string(&spec_path)
+        .with_context(|| format!("failed to read versions spec {}", spec_path.display()))?;
+    let spec: VersionSpecRoot = serde_yaml::from_str(&spec_contents)
+        .with_context(|| format!("failed to parse versions spec {}", spec_path.display()))?;
     let spec_dir = spec_path
         .parent()
         .ok_or_else(|| anyhow!("versions spec has no parent path"))?;
@@ -263,7 +265,17 @@ fn build_local_head_binaries(
         }
     };
 
-    Ok((rollup_bin.canonicalize()?, soak_bin.canonicalize()?))
+    Ok((
+        rollup_bin.canonicalize().with_context(|| {
+            format!(
+                "failed to canonicalize rollup binary {}",
+                rollup_bin.display()
+            )
+        })?,
+        soak_bin.canonicalize().with_context(|| {
+            format!("failed to canonicalize soak binary {}", soak_bin.display())
+        })?,
+    ))
 }
 
 fn render_config_template(
@@ -285,9 +297,19 @@ fn render_config_template(
 
 fn build_rollup_manager_binary(manager_build_root: &Path) -> Result<PathBuf, anyhow::Error> {
     if manager_build_root.exists() {
-        fs::remove_dir_all(manager_build_root)?;
+        fs::remove_dir_all(manager_build_root).with_context(|| {
+            format!(
+                "failed to remove existing rollup manager build directory {}",
+                manager_build_root.display()
+            )
+        })?;
     }
-    fs::create_dir_all(manager_build_root)?;
+    fs::create_dir_all(manager_build_root).with_context(|| {
+        format!(
+            "failed to create rollup manager build directory {}",
+            manager_build_root.display()
+        )
+    })?;
     let manager_repo = manager_build_root.join("repo");
     let manager_repo_arg = manager_repo.to_string_lossy().to_string();
 
@@ -321,7 +343,12 @@ fn build_rollup_manager_binary(manager_build_root: &Path) -> Result<PathBuf, any
             manager_bin.display()
         ));
     }
-    Ok(manager_bin.canonicalize()?)
+    Ok(manager_bin.canonicalize().with_context(|| {
+        format!(
+            "failed to canonicalize built manager binary {}",
+            manager_bin.display()
+        )
+    })?)
 }
 
 pub fn prepare_acceptance_run_plan(
@@ -344,7 +371,12 @@ pub fn prepare_acceptance_run_plan_with_constants(
     local_constants_manifest: LocalConstantsManifest,
 ) -> Result<AcceptanceRunPlan, anyhow::Error> {
     let binary_cache_dir = &directories.rollup_build_cache_dir;
-    fs::create_dir_all(binary_cache_dir)?;
+    fs::create_dir_all(binary_cache_dir).with_context(|| {
+        format!(
+            "failed to create rollup binary cache directory {}",
+            binary_cache_dir.display()
+        )
+    })?;
 
     let resolved_versions = load_version_sources(directories)?;
     let remote_commits: Vec<String> = resolved_versions
@@ -388,7 +420,12 @@ pub fn prepare_acceptance_run_plan_with_constants(
         build_local_head_binaries(directories, local_constants_manifest)?;
 
     let versioned_configs_dir = directories.output_dir.join("versioned-configs");
-    fs::create_dir_all(&versioned_configs_dir)?;
+    fs::create_dir_all(&versioned_configs_dir).with_context(|| {
+        format!(
+            "failed to create versioned config directory {}",
+            versioned_configs_dir.display()
+        )
+    })?;
 
     let mut manager_versions = Vec::with_capacity(resolved_versions.len());
     let mut soak_versions = Vec::with_capacity(resolved_versions.len());
@@ -428,14 +465,32 @@ pub fn prepare_acceptance_run_plan_with_constants(
                         } else {
                             directories.rollup_root.join(path)
                         };
-                        Some(migration_path.canonicalize()?)
+                        Some(migration_path.canonicalize().with_context(|| {
+                            format!(
+                                "failed to canonicalize migration path {} for remote commit {}",
+                                migration_path.display(),
+                                commit
+                            )
+                        })?)
                     } else {
                         None
                     };
 
                     (
-                        artifacts.rollup_binary.canonicalize()?,
-                        soak_binary.canonicalize()?,
+                        artifacts.rollup_binary.canonicalize().with_context(|| {
+                            format!(
+                                "failed to canonicalize rollup binary artifact {} for remote commit {}",
+                                artifacts.rollup_binary.display(),
+                                commit
+                            )
+                        })?,
+                        soak_binary.canonicalize().with_context(|| {
+                            format!(
+                                "failed to canonicalize soak binary artifact {} for remote commit {}",
+                                soak_binary.display(),
+                                commit
+                            )
+                        })?,
                         config_template,
                         migration_path,
                     )
@@ -447,17 +502,27 @@ pub fn prepare_acceptance_run_plan_with_constants(
                         } else {
                             directories.rollup_root.join(path)
                         };
-                        Some(migration_path.canonicalize()?)
+                        Some(migration_path.canonicalize().with_context(|| {
+                            format!(
+                                "failed to canonicalize local migration path {}",
+                                migration_path.display()
+                            )
+                        })?)
                     } else {
                         None
                     };
 
+                    let config_template_path =
+                        directories.acceptance_test_dir.join("rollup_config.toml");
                     (
                         local_rollup_bin.clone(),
                         local_soak_bin.clone(),
-                        fs::read_to_string(
-                            directories.acceptance_test_dir.join("rollup_config.toml"),
-                        )?,
+                        fs::read_to_string(&config_template_path).with_context(|| {
+                            format!(
+                                "failed to read local rollup config template {}",
+                                config_template_path.display()
+                            )
+                        })?,
                         migration_path,
                     )
                 }
@@ -465,7 +530,12 @@ pub fn prepare_acceptance_run_plan_with_constants(
 
         let interpolated = render_config_template(&config_template_content, password, directories);
         let config_path = versioned_configs_dir.join(format!("config_{}.toml", idx));
-        fs::write(&config_path, interpolated)?;
+        fs::write(&config_path, interpolated).with_context(|| {
+            format!(
+                "failed to write rendered versioned rollup config {}",
+                config_path.display()
+            )
+        })?;
 
         manager_versions.push(RollupVersion {
             rollup_binary,
@@ -512,12 +582,18 @@ pub fn extend_last_stop_height(
 
 pub fn write_manager_config(path: &Path, versions: &[RollupVersion]) -> Result<(), anyhow::Error> {
     if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "failed to create rollup manager config directory {}",
+                parent.display()
+            )
+        })?;
     }
     let manager_config = ManagerConfig {
         versions: versions.to_vec(),
     };
-    fs::write(path, serde_json::to_string_pretty(&manager_config)?)?;
+    fs::write(path, serde_json::to_string_pretty(&manager_config)?)
+        .with_context(|| format!("failed to write rollup manager config {}", path.display()))?;
     Ok(())
 }
 
@@ -571,10 +647,22 @@ pub fn spawn_rollup_manager(
 
     if let Some(path) = stdout_log_path {
         if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)?;
+            fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "failed to create rollup manager log directory {}",
+                    parent.display()
+                )
+            })?;
         }
-        let log_file = std::fs::File::create(path)?;
-        cmd.stdout(log_file.try_clone()?).stderr(log_file);
+        let log_file = std::fs::File::create(path)
+            .with_context(|| format!("failed to create rollup manager log {}", path.display()))?;
+        cmd.stdout(log_file.try_clone().with_context(|| {
+            format!(
+                "failed to clone rollup manager log handle {}",
+                path.display()
+            )
+        })?)
+        .stderr(log_file);
     }
 
     let child = cmd.spawn().with_context(|| {


### PR DESCRIPTION
First commit: adds contexts to errors, so it's more obvious from the logs why tests fail if something goes wrong at the OS level. Avoids issues like `ERROR acceptance_test: Acceptance test failed: No such file or directory (os error 2)` that are impossible to debug from logs.

Second commit: relaxes the throughput check for the `--short` run, which only runs for 30 blocks and therefore has a lot more variance (since startup time also affects the throughput calculation). The short run is a smoke test anyway; the full test run will pick up any actual throughput regression, while the short run is just a sanity check to make sure the rollup actually runs and produces some reasonable transactions.