### PR TITLE
Update to the latest dev 2026-06-17

### DIFF
--- a/.claude/commands/sdk-upgrade-to-latest-dev.md
+++ b/.claude/commands/sdk-upgrade-to-latest-dev.md
@@ -31,7 +31,7 @@ Before making changes, understand what's new in the SDK:
    ```bash
    gh api repos/Sovereign-Labs/sovereign-sdk/compare/{prev}...{new} --jq '.files[] | select(.filename | startswith("examples/demo-rollup/")) | .filename'
    ```
-3. **Check for new constants**: Look for changes to the SDK's constants files that might require new entries in our `constants.toml`.
+3. **Check for new constants**: Look for changes to the SDK's constants files that might require new entries in our `constants.toml` and in `scripts/acceptance-test/constants.testing.toml`.
 
 Report findings to the user before proceeding.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6424,7 +6424,7 @@ dependencies = [
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 
 [[package]]
 name = "nix"
@@ -10723,7 +10723,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -10738,7 +10738,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -10759,7 +10759,7 @@ dependencies = [
 [[package]]
 name = "sov-api-spec"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "backon",
@@ -10783,7 +10783,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10803,7 +10803,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10823,7 +10823,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-sender"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10845,7 +10845,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10864,7 +10864,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10875,7 +10875,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -10895,7 +10895,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -10929,10 +10929,11 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
+ "futures",
  "schemars 1.2.1",
  "serde",
  "sov-modules-api",
@@ -10945,7 +10946,7 @@ dependencies = [
 [[package]]
 name = "sov-cli"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10968,7 +10969,7 @@ dependencies = [
 [[package]]
 name = "sov-db"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11000,7 +11001,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -11018,7 +11019,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11033,7 +11034,7 @@ dependencies = [
 [[package]]
 name = "sov-eth-client"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -11060,7 +11061,7 @@ dependencies = [
 [[package]]
 name = "sov-eth-dev-signer"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11071,7 +11072,7 @@ dependencies = [
 [[package]]
 name = "sov-ethereum"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11102,7 +11103,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11143,7 +11144,7 @@ dependencies = [
 [[package]]
 name = "sov-evm-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -11159,7 +11160,7 @@ dependencies = [
 [[package]]
 name = "sov-full-node-configs"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -11174,7 +11175,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11198,7 +11199,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -11211,7 +11212,7 @@ dependencies = [
 [[package]]
 name = "sov-ledger-apis"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11232,7 +11233,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -11254,7 +11255,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11288,7 +11289,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11308,7 +11309,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11355,7 +11356,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "bech32",
@@ -11377,7 +11378,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-rollup-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11408,6 +11409,7 @@ dependencies = [
  "sov-stf-runner",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-opentelemetry",
  "tracing-panic",
  "tracing-subscriber 0.3.23",
@@ -11416,7 +11418,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11433,7 +11435,7 @@ dependencies = [
 [[package]]
 name = "sov-node-client"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11452,7 +11454,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11465,7 +11467,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11482,7 +11484,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11502,7 +11504,7 @@ dependencies = [
 [[package]]
 name = "sov-proxy-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11519,7 +11521,7 @@ dependencies = [
 [[package]]
 name = "sov-rest-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11543,7 +11545,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11558,7 +11560,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11586,7 +11588,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-apis"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "axum 0.8.8",
  "borsh",
@@ -11607,7 +11609,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-full-node-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "derive_more 2.1.1",
  "rockbound",
@@ -11619,7 +11621,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11665,7 +11667,7 @@ dependencies = [
 [[package]]
 name = "sov-rpc-eth-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11685,7 +11687,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11732,7 +11734,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11765,7 +11767,7 @@ dependencies = [
 [[package]]
 name = "sov-soak-testing-lib"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "clap",
@@ -11783,7 +11785,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11812,7 +11814,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11837,7 +11839,7 @@ dependencies = [
 [[package]]
 name = "sov-stf-runner"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11853,6 +11855,7 @@ dependencies = [
  "rayon",
  "rockbound",
  "serde",
+ "serde_json",
  "sov-db",
  "sov-full-node-configs",
  "sov-metrics",
@@ -11871,7 +11874,7 @@ dependencies = [
 [[package]]
 name = "sov-synthetic-load"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11887,7 +11890,7 @@ dependencies = [
 [[package]]
 name = "sov-test-modules"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11905,7 +11908,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11920,7 +11923,7 @@ dependencies = [
 [[package]]
 name = "sov-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11981,7 +11984,7 @@ dependencies = [
 [[package]]
 name = "sov-transaction-generator"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12014,10 +12017,11 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
+ "serde",
  "sov-modules-api",
  "sov-state",
 ]
@@ -12025,7 +12029,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -12047,7 +12051,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "bech32",
  "borsh",
@@ -12062,7 +12066,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -12071,7 +12075,7 @@ dependencies = [
 [[package]]
 name = "sov-value-setter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12096,7 +12100,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6424,7 +6424,7 @@ dependencies = [
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 
 [[package]]
 name = "nix"
@@ -10723,7 +10723,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -10738,7 +10738,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -10759,7 +10759,7 @@ dependencies = [
 [[package]]
 name = "sov-api-spec"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "backon",
@@ -10783,7 +10783,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10803,7 +10803,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10823,7 +10823,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-sender"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10845,7 +10845,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10864,7 +10864,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10875,7 +10875,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -10895,7 +10895,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -10929,7 +10929,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10946,7 +10946,7 @@ dependencies = [
 [[package]]
 name = "sov-cli"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10969,7 +10969,7 @@ dependencies = [
 [[package]]
 name = "sov-db"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11001,7 +11001,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -11019,7 +11019,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11034,7 +11034,7 @@ dependencies = [
 [[package]]
 name = "sov-eth-client"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -11061,7 +11061,7 @@ dependencies = [
 [[package]]
 name = "sov-eth-dev-signer"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11072,7 +11072,7 @@ dependencies = [
 [[package]]
 name = "sov-ethereum"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11103,7 +11103,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11144,7 +11144,7 @@ dependencies = [
 [[package]]
 name = "sov-evm-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -11160,7 +11160,7 @@ dependencies = [
 [[package]]
 name = "sov-full-node-configs"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -11175,7 +11175,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11199,7 +11199,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -11212,7 +11212,7 @@ dependencies = [
 [[package]]
 name = "sov-ledger-apis"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11233,7 +11233,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -11255,7 +11255,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11289,7 +11289,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11309,7 +11309,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11356,7 +11356,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "bech32",
@@ -11378,7 +11378,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-rollup-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11418,7 +11418,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11435,7 +11435,7 @@ dependencies = [
 [[package]]
 name = "sov-node-client"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11454,7 +11454,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11467,7 +11467,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11484,7 +11484,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11504,7 +11504,7 @@ dependencies = [
 [[package]]
 name = "sov-proxy-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11521,7 +11521,7 @@ dependencies = [
 [[package]]
 name = "sov-rest-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11545,7 +11545,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11560,7 +11560,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11588,7 +11588,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-apis"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "axum 0.8.8",
  "borsh",
@@ -11609,7 +11609,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-full-node-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "derive_more 2.1.1",
  "rockbound",
@@ -11621,7 +11621,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11667,7 +11667,7 @@ dependencies = [
 [[package]]
 name = "sov-rpc-eth-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11687,7 +11687,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11734,7 +11734,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11767,7 +11767,7 @@ dependencies = [
 [[package]]
 name = "sov-soak-testing-lib"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "clap",
@@ -11785,7 +11785,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11809,12 +11809,13 @@ dependencies = [
  "sp1-sdk",
  "sp1-verifier",
  "sp1-zkvm",
+ "tokio",
 ]
 
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11839,7 +11840,7 @@ dependencies = [
 [[package]]
 name = "sov-stf-runner"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11874,7 +11875,7 @@ dependencies = [
 [[package]]
 name = "sov-synthetic-load"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11890,7 +11891,7 @@ dependencies = [
 [[package]]
 name = "sov-test-modules"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11908,7 +11909,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11923,7 +11924,7 @@ dependencies = [
 [[package]]
 name = "sov-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11984,7 +11985,7 @@ dependencies = [
 [[package]]
 name = "sov-transaction-generator"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12017,7 +12018,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12029,7 +12030,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -12051,7 +12052,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "bech32",
  "borsh",
@@ -12066,7 +12067,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -12075,7 +12076,7 @@ dependencies = [
 [[package]]
 name = "sov-value-setter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12100,7 +12101,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,57 +22,57 @@ publish = false
 rust-version = "1.93"
 
 [workspace.dependencies]
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6", features = [
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a", features = [
   "evm",
 ] }
-sov-accounts = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-api-spec = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-attester-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-chain-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-bank = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-blob-storage = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-paymaster = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-capabilities = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-cli = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-hyperlane-integration = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6", features = [
+sov-accounts = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-api-spec = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-attester-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-chain-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-bank = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-blob-storage = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-paymaster = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-capabilities = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-cli = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-hyperlane-integration = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a", features = [
   "evm",
 ] }
-sov-eth-client = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-test-state-consistency = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-ledger-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-modules-rollup-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-uniqueness = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-operator-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-prover-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-revenue-share = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-rollup-full-node-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-sequencer = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-sequencer-registry = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-soak-testing-lib = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-stf-runner = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-test-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-rollup-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-universal-wallet = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-zkvm-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-build = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-ethereum = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-evm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-soak-testing = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-eip712-auth = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-rest-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-proxy-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6", features = ["native"] }
+sov-eth-client = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-test-state-consistency = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-ledger-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-modules-rollup-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-uniqueness = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-operator-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-prover-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-revenue-share = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-rollup-full-node-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-sequencer = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-sequencer-registry = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-soak-testing-lib = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-stf-runner = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-test-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-rollup-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-universal-wallet = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-zkvm-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-build = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-ethereum = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-evm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-soak-testing = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-eip712-auth = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-rest-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-proxy-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a", features = ["native"] }
 
 
 stf-starter = { path = "./crates/stf", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,57 +22,57 @@ publish = false
 rust-version = "1.93"
 
 [workspace.dependencies]
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a", features = [
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b", features = [
   "evm",
 ] }
-sov-accounts = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-api-spec = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-attester-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-chain-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-bank = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-blob-storage = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-paymaster = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-capabilities = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-cli = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-hyperlane-integration = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a", features = [
+sov-accounts = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-api-spec = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-attester-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-chain-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-bank = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-blob-storage = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-paymaster = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-capabilities = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-cli = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-hyperlane-integration = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b", features = [
   "evm",
 ] }
-sov-eth-client = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-test-state-consistency = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-ledger-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-modules-rollup-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-uniqueness = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-operator-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-prover-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-revenue-share = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-rollup-full-node-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-sequencer = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-sequencer-registry = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-soak-testing-lib = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-stf-runner = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-test-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-rollup-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-universal-wallet = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-zkvm-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-build = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-ethereum = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-evm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-soak-testing = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-eip712-auth = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-rest-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-proxy-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a", features = ["native"] }
+sov-eth-client = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-test-state-consistency = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-ledger-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-modules-rollup-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-uniqueness = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-operator-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-prover-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-revenue-share = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-rollup-full-node-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-sequencer = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-sequencer-registry = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-soak-testing-lib = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-stf-runner = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-test-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-rollup-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-universal-wallet = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-zkvm-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-build = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-ethereum = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-evm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-soak-testing = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-eip712-auth = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-rest-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-proxy-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b", features = ["native"] }
 
 
 stf-starter = { path = "./crates/stf", default-features = false }

--- a/GETTING_STARTED_WITH_HYPERLANE.md
+++ b/GETTING_STARTED_WITH_HYPERLANE.md
@@ -65,7 +65,7 @@ $ make print-hyperlane-ethtest-warp
       symbol: ETH
       decimals: 18
       isNft: false
-      contractVersion: 9.0.6
+      contractVersion: 10.1.5
       type: native
       allowedRebalancers: []
       allowedRebalancingBridges: {}
@@ -202,7 +202,7 @@ $ cd ../../ && make print-hyperlane-ethtest-warp
       symbol: ETH
       decimals: 18
       isNft: false
-      contractVersion: 9.0.6
+      contractVersion: 10.1.5
       type: native
       allowedRebalancers: []
       allowedRebalancingBridges: {}

--- a/constants.toml
+++ b/constants.toml
@@ -86,7 +86,7 @@ GAS_TOKEN_ID = { bech32 = "token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2
 # The number of decimal places of the rollup's gas token. This is the authoritative source of
 # truth for the gas token's decimals: unlike normal tokens (whose decimals are encoded in the last
 # byte of their id), the gas token id is a fixed constant whose last byte might not always encode the decimals.
-GAS_TOKEN_DECIMALS = 6
+GAS_TOKEN_DECIMALS = 89
 # The HRP prefix that appears in all rollup addresses.
 ADDRESS_PREFIX = { const = "sov" }
 # --- Gas parameters to charge for state accesses ---

--- a/constants.toml
+++ b/constants.toml
@@ -86,7 +86,7 @@ GAS_TOKEN_ID = { bech32 = "token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2
 # The number of decimal places of the rollup's gas token. This is the authoritative source of
 # truth for the gas token's decimals: unlike normal tokens (whose decimals are encoded in the last
 # byte of their id), the gas token id is a fixed constant whose last byte might not always encode the decimals.
-GAS_TOKEN_DECIMALS = 89
+GAS_TOKEN_DECIMALS = 18
 # The HRP prefix that appears in all rollup addresses.
 ADDRESS_PREFIX = { const = "sov" }
 # --- Gas parameters to charge for state accesses ---

--- a/constants.toml
+++ b/constants.toml
@@ -83,6 +83,10 @@ GAS_DIMENSIONS = { const = 2 }
 GAS_FORCED_SEQUENCER_REGISTRATION_COST = [100000, 100000]
 # The ID of the "native token" of the rollup, which is used to pay gas fees.
 GAS_TOKEN_ID = { bech32 = "token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7", type = "TokenId" }
+# The number of decimal places of the rollup's gas token. This is the authoritative source of
+# truth for the gas token's decimals: unlike normal tokens (whose decimals are encoded in the last
+# byte of their id), the gas token id is a fixed constant whose last byte might not always encode the decimals.
+GAS_TOKEN_DECIMALS = 6
 # The HRP prefix that appears in all rollup addresses.
 ADDRESS_PREFIX = { const = "sov" }
 # --- Gas parameters to charge for state accesses ---

--- a/crates/provers/risc0/guest-celestia/Cargo.lock
+++ b/crates/provers/risc0/guest-celestia/Cargo.lock
@@ -2467,7 +2467,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 
 [[package]]
 name = "nmt-rs"
@@ -4071,7 +4071,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4085,7 +4085,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4103,7 +4103,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4122,7 +4122,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4160,7 +4160,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4171,7 +4171,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -4191,7 +4191,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4218,7 +4218,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4234,7 +4234,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "borsh",
  "derivative",
@@ -4268,7 +4268,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4283,7 +4283,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4319,7 +4319,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4340,7 +4340,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -4353,7 +4353,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4367,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4385,7 +4385,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4415,7 +4415,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4437,7 +4437,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4454,7 +4454,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4467,7 +4467,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4484,7 +4484,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4504,7 +4504,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4519,7 +4519,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4544,7 +4544,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4565,7 +4565,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4581,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4601,7 +4601,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4616,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4628,7 +4628,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4650,7 +4650,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "bech32",
  "borsh",
@@ -4665,7 +4665,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -4674,7 +4674,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/risc0/guest-celestia/Cargo.lock
+++ b/crates/provers/risc0/guest-celestia/Cargo.lock
@@ -2467,7 +2467,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 
 [[package]]
 name = "nmt-rs"
@@ -4071,7 +4071,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4085,7 +4085,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4103,7 +4103,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4122,7 +4122,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4160,7 +4160,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4171,7 +4171,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -4191,7 +4191,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4218,7 +4218,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4234,7 +4234,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "borsh",
  "derivative",
@@ -4268,7 +4268,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4283,7 +4283,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4319,7 +4319,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4340,7 +4340,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -4353,7 +4353,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4367,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4385,7 +4385,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4415,7 +4415,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4437,7 +4437,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4454,7 +4454,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4467,7 +4467,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4484,7 +4484,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4504,7 +4504,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4519,7 +4519,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4544,7 +4544,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4565,7 +4565,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4581,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4601,7 +4601,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4616,10 +4616,11 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
+ "serde",
  "sov-modules-api",
  "sov-state",
 ]
@@ -4627,7 +4628,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4649,7 +4650,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "bech32",
  "borsh",
@@ -4664,7 +4665,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -4673,7 +4674,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/risc0/guest-celestia/Cargo.toml
+++ b/crates/provers/risc0/guest-celestia/Cargo.toml
@@ -12,16 +12,16 @@ anyhow = { version = "1.0.95" }
 risc0-zkvm = { version = "3.0", default-features = false, features = ["std"] }
 risc0-zkvm-platform = { version = "2.2" }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["celestia_da"] }
 

--- a/crates/provers/risc0/guest-celestia/Cargo.toml
+++ b/crates/provers/risc0/guest-celestia/Cargo.toml
@@ -12,16 +12,16 @@ anyhow = { version = "1.0.95" }
 risc0-zkvm = { version = "3.0", default-features = false, features = ["std"] }
 risc0-zkvm-platform = { version = "2.2" }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["celestia_da"] }
 

--- a/crates/provers/risc0/guest-mock/Cargo.lock
+++ b/crates/provers/risc0/guest-mock/Cargo.lock
@@ -2617,7 +2617,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 
 [[package]]
 name = "nmt-rs"
@@ -4236,7 +4236,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4250,7 +4250,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4268,7 +4268,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4287,7 +4287,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4306,7 +4306,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4325,7 +4325,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4336,7 +4336,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -4356,7 +4356,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4383,7 +4383,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4399,7 +4399,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "borsh",
  "derivative",
@@ -4413,7 +4413,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4428,7 +4428,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4464,7 +4464,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4485,7 +4485,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -4498,7 +4498,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4512,7 +4512,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4533,7 +4533,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4551,7 +4551,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4581,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4603,7 +4603,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4620,7 +4620,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4633,7 +4633,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4650,7 +4650,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4670,7 +4670,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4685,7 +4685,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4710,7 +4710,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4731,7 +4731,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4747,7 +4747,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4767,7 +4767,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4782,7 +4782,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4794,7 +4794,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4816,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "bech32",
  "borsh",
@@ -4831,7 +4831,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -4840,7 +4840,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/risc0/guest-mock/Cargo.lock
+++ b/crates/provers/risc0/guest-mock/Cargo.lock
@@ -2617,7 +2617,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 
 [[package]]
 name = "nmt-rs"
@@ -4236,7 +4236,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4250,7 +4250,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4268,7 +4268,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4287,7 +4287,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4306,7 +4306,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4325,7 +4325,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4336,7 +4336,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -4356,7 +4356,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4383,7 +4383,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4399,7 +4399,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "borsh",
  "derivative",
@@ -4413,7 +4413,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4428,7 +4428,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4464,7 +4464,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4485,7 +4485,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -4498,7 +4498,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4512,7 +4512,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4533,7 +4533,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4551,7 +4551,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4581,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4603,7 +4603,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4620,7 +4620,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4633,7 +4633,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4650,7 +4650,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4670,7 +4670,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4685,7 +4685,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4710,7 +4710,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4731,7 +4731,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4747,7 +4747,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4767,7 +4767,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4782,10 +4782,11 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
+ "serde",
  "sov-modules-api",
  "sov-state",
 ]
@@ -4793,7 +4794,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4815,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "bech32",
  "borsh",
@@ -4830,7 +4831,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -4839,7 +4840,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/risc0/guest-mock/Cargo.toml
+++ b/crates/provers/risc0/guest-mock/Cargo.toml
@@ -15,16 +15,16 @@ risc0-zkvm-platform = { version = "2.2" }
 serde = { version = "1.0.188", features = ["derive", "rc"] }
 
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b", optional = true }
 
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["mock_da"] }

--- a/crates/provers/risc0/guest-mock/Cargo.toml
+++ b/crates/provers/risc0/guest-mock/Cargo.toml
@@ -15,16 +15,16 @@ risc0-zkvm-platform = { version = "2.2" }
 serde = { version = "1.0.188", features = ["derive", "rc"] }
 
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a", optional = true }
 
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["mock_da"] }

--- a/crates/provers/sp1/guest-celestia/Cargo.lock
+++ b/crates/provers/sp1/guest-celestia/Cargo.lock
@@ -3448,7 +3448,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 
 [[package]]
 name = "nmt-rs"
@@ -6100,7 +6100,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6114,7 +6114,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6132,7 +6132,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6151,7 +6151,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6170,7 +6170,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6189,7 +6189,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6200,7 +6200,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -6220,7 +6220,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6247,7 +6247,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6263,7 +6263,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "borsh",
  "derivative",
@@ -6296,7 +6296,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6311,7 +6311,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6347,7 +6347,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6368,7 +6368,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -6381,7 +6381,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6394,7 +6394,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6412,7 +6412,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6442,7 +6442,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6464,7 +6464,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6481,7 +6481,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6494,7 +6494,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6511,7 +6511,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6531,7 +6531,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6546,7 +6546,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6567,7 +6567,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6583,7 +6583,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6608,7 +6608,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6628,7 +6628,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6643,7 +6643,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6655,7 +6655,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -6677,7 +6677,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "bech32",
  "borsh",
@@ -6692,7 +6692,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -6701,7 +6701,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/sp1/guest-celestia/Cargo.lock
+++ b/crates/provers/sp1/guest-celestia/Cargo.lock
@@ -3448,7 +3448,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 
 [[package]]
 name = "nmt-rs"
@@ -6100,7 +6100,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6114,7 +6114,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6132,7 +6132,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6151,7 +6151,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6170,7 +6170,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6189,7 +6189,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6200,7 +6200,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -6220,7 +6220,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6247,7 +6247,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6263,7 +6263,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "borsh",
  "derivative",
@@ -6296,7 +6296,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6311,7 +6311,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6347,7 +6347,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6368,7 +6368,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -6381,7 +6381,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6394,7 +6394,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6412,7 +6412,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6442,7 +6442,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6464,7 +6464,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6481,7 +6481,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6494,7 +6494,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6511,7 +6511,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6531,7 +6531,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6546,7 +6546,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6567,7 +6567,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6583,7 +6583,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6608,7 +6608,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6628,7 +6628,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6643,10 +6643,11 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
+ "serde",
  "sov-modules-api",
  "sov-state",
 ]
@@ -6654,7 +6655,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -6676,7 +6677,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "bech32",
  "borsh",
@@ -6691,7 +6692,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -6700,7 +6701,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/sp1/guest-celestia/Cargo.toml
+++ b/crates/provers/sp1/guest-celestia/Cargo.toml
@@ -10,16 +10,16 @@ resolver = "2"
 anyhow = { version = "1.0.95" }
 sp1-zkvm = { version = "6.2.2" }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["celestia_da"] }
 

--- a/crates/provers/sp1/guest-celestia/Cargo.toml
+++ b/crates/provers/sp1/guest-celestia/Cargo.toml
@@ -10,16 +10,16 @@ resolver = "2"
 anyhow = { version = "1.0.95" }
 sp1-zkvm = { version = "6.2.2" }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["celestia_da"] }
 

--- a/crates/provers/sp1/guest-mock/Cargo.lock
+++ b/crates/provers/sp1/guest-mock/Cargo.lock
@@ -3467,7 +3467,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 
 [[package]]
 name = "nmt-rs"
@@ -6119,7 +6119,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6133,7 +6133,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6151,7 +6151,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6170,7 +6170,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6189,7 +6189,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6208,7 +6208,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6219,7 +6219,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -6239,7 +6239,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6266,7 +6266,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6282,7 +6282,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "borsh",
  "derivative",
@@ -6296,7 +6296,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6311,7 +6311,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6347,7 +6347,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6368,7 +6368,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -6381,7 +6381,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6394,7 +6394,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6415,7 +6415,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6433,7 +6433,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6463,7 +6463,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6485,7 +6485,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6502,7 +6502,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6515,7 +6515,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6532,7 +6532,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6552,7 +6552,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6567,7 +6567,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6588,7 +6588,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6604,7 +6604,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6629,7 +6629,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6649,7 +6649,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6664,7 +6664,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6676,7 +6676,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -6698,7 +6698,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "bech32",
  "borsh",
@@ -6713,7 +6713,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -6722,7 +6722,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/sp1/guest-mock/Cargo.lock
+++ b/crates/provers/sp1/guest-mock/Cargo.lock
@@ -3467,7 +3467,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 
 [[package]]
 name = "nmt-rs"
@@ -6119,7 +6119,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6133,7 +6133,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6151,7 +6151,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6170,7 +6170,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6189,7 +6189,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6208,7 +6208,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6219,7 +6219,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -6239,7 +6239,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6266,7 +6266,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6282,7 +6282,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "borsh",
  "derivative",
@@ -6296,7 +6296,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6311,7 +6311,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6347,7 +6347,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6368,7 +6368,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -6381,7 +6381,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6394,7 +6394,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6415,7 +6415,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6433,7 +6433,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6463,7 +6463,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6485,7 +6485,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6502,7 +6502,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6515,7 +6515,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6532,7 +6532,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6552,7 +6552,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6567,7 +6567,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6588,7 +6588,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6604,7 +6604,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6629,7 +6629,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6649,7 +6649,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6664,10 +6664,11 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "borsh",
+ "serde",
  "sov-modules-api",
  "sov-state",
 ]
@@ -6675,7 +6676,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -6697,7 +6698,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "bech32",
  "borsh",
@@ -6712,7 +6713,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -6721,7 +6722,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=f2a966a4756bdeeee885fc3174886791f501e3c6#f2a966a4756bdeeee885fc3174886791f501e3c6"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=243aac478626bd5aa2eac1cf9dfd256e8ec9444a#243aac478626bd5aa2eac1cf9dfd256e8ec9444a"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/sp1/guest-mock/Cargo.toml
+++ b/crates/provers/sp1/guest-mock/Cargo.toml
@@ -10,16 +10,16 @@ resolver = "2"
 anyhow = { version = "1.0.95" }
 sp1-zkvm = { version = "6.2.2" }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "f2a966a4756bdeeee885fc3174886791f501e3c6", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["mock_da"] }
 

--- a/crates/provers/sp1/guest-mock/Cargo.toml
+++ b/crates/provers/sp1/guest-mock/Cargo.toml
@@ -10,16 +10,16 @@ resolver = "2"
 anyhow = { version = "1.0.95" }
 sp1-zkvm = { version = "6.2.2" }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "243aac478626bd5aa2eac1cf9dfd256e8ec9444a", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["mock_da"] }
 

--- a/integrations/hyperlane/docker-compose.hyp-evm.yml
+++ b/integrations/hyperlane/docker-compose.hyp-evm.yml
@@ -16,7 +16,7 @@ services:
       - "8545:8545"
 
   hyperlane-core-deploy:
-    image: ghcr.io/sovereign-labs/hyperlane-cli:sov-integration-3
+    image: ghcr.io/sovereign-labs/hyperlane-cli:sov-integration-12
     depends_on:
       anvil:
         condition: service_healthy
@@ -34,7 +34,7 @@ services:
       --yes
 
   hyperlane-warp-deploy:
-    image: ghcr.io/sovereign-labs/hyperlane-cli:sov-integration-3
+    image: ghcr.io/sovereign-labs/hyperlane-cli:sov-integration-12
     depends_on:
       hyperlane-core-deploy:
         condition: service_completed_successfully
@@ -51,7 +51,7 @@ services:
       --yes
 
   validator-ethtest:
-    image: ghcr.io/ross-weir/hyperlane-agent:integration-10
+    image: ghcr.io/ross-weir/hyperlane-agent:integration-lander-2
     depends_on:
       hyperlane-warp-deploy:
         condition: service_completed_successfully
@@ -97,7 +97,7 @@ services:
   # TODO: validator-sovstarter
 
   relayer:
-    image: ghcr.io/ross-weir/hyperlane-agent:integration-10
+    image: ghcr.io/ross-weir/hyperlane-agent:integration-lander-2
     depends_on:
       hyperlane-warp-deploy:
         condition: service_completed_successfully
@@ -142,7 +142,7 @@ services:
 
   # Utility service for running hyperlane-cli commands
   hyperlane-cli:
-    image: ghcr.io/sovereign-labs/hyperlane-cli:sov-integration-3
+    image: ghcr.io/sovereign-labs/hyperlane-cli:sov-integration-12
     profiles: ["cli"]
     depends_on:
       anvil:

--- a/scripts/acceptance-test/constants.testing.toml
+++ b/scripts/acceptance-test/constants.testing.toml
@@ -22,7 +22,7 @@ CHAIN_NAME = "TestChain"
 # The optional `grace_period` field (defaults to 0) specifies how many blocks after end_height
 # the old hash will still be accepted alongside the new hash, allowing for smooth transitions.
 # Example: CHAIN_HASH_OVERRIDES = [{ start_height = 0, end_height = 1000, chain_hash = "0xabc...32_bytes_hex", grace_period = 100 }]
-CHAIN_HASH_OVERRIDES = []
+CHAIN_HASH_OVERRIDES = [{ start_height = 0, end_height = 1003, chain_hash = "0x4198ee1412a2cb2305b8fc99de14751865bdad680ee4a67cd28301ce8f2de753" }]
 
 # The namespace used by the rollup to store its data.
 # Using byte_string to convert to ASCII bytes
@@ -86,7 +86,7 @@ GAS_DIMENSIONS = { const = 2 }
 GAS_FORCED_SEQUENCER_REGISTRATION_COST = [100000, 100000]
 # The ID of the "native token" of the rollup, which is used to pay gas fees.
 GAS_TOKEN_ID = { bech32 = "token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7", type = "TokenId" }
-GAS_TOKEN_DECIMALS = 89
+GAS_TOKEN_DECIMALS = 18
 # The HRP prefix that appears in all rollup addresses.
 ADDRESS_PREFIX = { const = "sov" }
 # --- Gas parameters to charge for state accesses ---

--- a/scripts/acceptance-test/constants.testing.toml
+++ b/scripts/acceptance-test/constants.testing.toml
@@ -86,7 +86,7 @@ GAS_DIMENSIONS = { const = 2 }
 GAS_FORCED_SEQUENCER_REGISTRATION_COST = [100000, 100000]
 # The ID of the "native token" of the rollup, which is used to pay gas fees.
 GAS_TOKEN_ID = { bech32 = "token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7", type = "TokenId" }
-GAS_TOKEN_DECIMALS = 6
+GAS_TOKEN_DECIMALS = 89
 # The HRP prefix that appears in all rollup addresses.
 ADDRESS_PREFIX = { const = "sov" }
 # --- Gas parameters to charge for state accesses ---

--- a/scripts/acceptance-test/constants.testing.toml
+++ b/scripts/acceptance-test/constants.testing.toml
@@ -86,6 +86,7 @@ GAS_DIMENSIONS = { const = 2 }
 GAS_FORCED_SEQUENCER_REGISTRATION_COST = [100000, 100000]
 # The ID of the "native token" of the rollup, which is used to pay gas fees.
 GAS_TOKEN_ID = { bech32 = "token_1nyl0e0yweragfsatygt24zmd8jrr2vqtvdfptzjhxkguz2xxx3vs0y07u7", type = "TokenId" }
+GAS_TOKEN_DECIMALS = 6
 # The HRP prefix that appears in all rollup addresses.
 ADDRESS_PREFIX = { const = "sov" }
 # --- Gas parameters to charge for state accesses ---


### PR DESCRIPTION
## Summary
Upgrades the pinned `sovereign-sdk` revision to the latest `dev`:
- **prev**: `f2a966a4756bdeeee885fc3174886791f501e3c6`
- **new**: `243aac478626bd5aa2eac1cf9dfd256e8ec9444a` (2026-06-17)

29 SDK commits, almost entirely internal work. The only change the starter required is one new constant.

## Changes
- Bump SDK rev across all 6 manifests (`Cargo.toml`, `scripts/soak-test/Cargo.toml`, the 4 prover guest manifests) + refreshed `Cargo.lock` files.
- **`constants.toml`: add `GAS_TOKEN_DECIMALS = 6`** — newly consumed by `sov-bank` via `config_value!` as the authoritative gas-token decimals (a missing key is a manifest-parse error). Value `6` matches the SDK default; our `GAS_TOKEN_ID` is the SDK demo token.

## Breaking-change assessment (why the diff is so small)
The starter is a thin wrapper over the SDK blueprint, so the SDK's breaking changes are absorbed without code changes:
- `create_new_rollup_with_genesis_params` → `_with_genesis_source`: we call `create_new_rollup(&path, …)`, whose signature is unchanged (the default impl now wraps paths in `GenesisSource::Paths`).
- New required `ChainState::genesis_da_height`: we use the SDK `SoftConfirmationsKernel` + `sov_chain_state::ChainState`; the SDK provides the impl.
- `start_http_server` / `rpc_module_to_router` gain `rpc_aggregation`: we delegate to `register_endpoints` / `Rollup::run`; internal.
- `monitoring.rpc_aggregation` config section: `#[serde(default)]`; existing `[monitoring]` configs deserialize unchanged.
- `ApiState::build` shutdown receiver, removed slot-number coercions, `SlotEvents` field rename: not used by the starter.
- `EthRpcConfig` / `get_ethereum_rpc`: signatures unchanged.

## Verification
- `make lint` ✅ (fmt, cargo check across feature combos, clippy, zepter)
- `make check` ✅ (lockfiles refreshed)
- `cargo nextest run` ✅ (4/4 passed, incl. `rollup-starter::all_tests bank::bank_tx_tests` end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sovereign-labs/rollup-starter/pull/188" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->