### PR TITLE
Update to the latest dev 2026-06-23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6424,7 +6424,7 @@ dependencies = [
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 
 [[package]]
 name = "nix"
@@ -6465,6 +6465,7 @@ dependencies = [
  "clap",
  "sov-metrics",
  "sov-proxy-utils",
+ "sov-rollup-interface",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.23",
@@ -10723,7 +10724,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -10738,7 +10739,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -10759,7 +10760,7 @@ dependencies = [
 [[package]]
 name = "sov-api-spec"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "backon",
@@ -10783,7 +10784,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10803,7 +10804,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10823,7 +10824,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-sender"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10845,7 +10846,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10864,7 +10865,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10875,7 +10876,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -10895,7 +10896,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -10929,7 +10930,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10946,7 +10947,7 @@ dependencies = [
 [[package]]
 name = "sov-cli"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10969,7 +10970,7 @@ dependencies = [
 [[package]]
 name = "sov-db"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11001,7 +11002,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -11019,7 +11020,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11034,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "sov-eth-client"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -11061,7 +11062,7 @@ dependencies = [
 [[package]]
 name = "sov-eth-dev-signer"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11072,7 +11073,7 @@ dependencies = [
 [[package]]
 name = "sov-ethereum"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11103,7 +11104,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11144,7 +11145,7 @@ dependencies = [
 [[package]]
 name = "sov-evm-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -11160,7 +11161,7 @@ dependencies = [
 [[package]]
 name = "sov-full-node-configs"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -11175,7 +11176,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11199,7 +11200,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -11212,7 +11213,7 @@ dependencies = [
 [[package]]
 name = "sov-ledger-apis"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11233,7 +11234,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -11246,6 +11247,7 @@ dependencies = [
  "risc0-zkvm-platform",
  "schemars 1.2.1",
  "serde",
+ "sov-rollup-interface",
  "sp1-lib",
  "tokio",
  "tokio-metrics",
@@ -11255,7 +11257,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11289,7 +11291,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11309,7 +11311,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11356,7 +11358,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "bech32",
@@ -11378,7 +11380,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-rollup-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11418,7 +11420,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11435,7 +11437,7 @@ dependencies = [
 [[package]]
 name = "sov-node-client"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11454,7 +11456,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11467,7 +11469,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11484,7 +11486,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11504,7 +11506,7 @@ dependencies = [
 [[package]]
 name = "sov-proxy-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11521,7 +11523,7 @@ dependencies = [
 [[package]]
 name = "sov-rest-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11545,7 +11547,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11560,7 +11562,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11588,7 +11590,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-apis"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "axum 0.8.8",
  "borsh",
@@ -11609,7 +11611,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-full-node-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "derive_more 2.1.1",
  "rockbound",
@@ -11621,7 +11623,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11667,7 +11669,7 @@ dependencies = [
 [[package]]
 name = "sov-rpc-eth-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11687,7 +11689,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11734,7 +11736,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11767,7 +11769,7 @@ dependencies = [
 [[package]]
 name = "sov-soak-testing-lib"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "clap",
@@ -11785,7 +11787,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11815,7 +11817,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11840,7 +11842,7 @@ dependencies = [
 [[package]]
 name = "sov-stf-runner"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11875,7 +11877,7 @@ dependencies = [
 [[package]]
 name = "sov-synthetic-load"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11891,7 +11893,7 @@ dependencies = [
 [[package]]
 name = "sov-test-modules"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11909,7 +11911,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11924,7 +11926,7 @@ dependencies = [
 [[package]]
 name = "sov-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11985,7 +11987,7 @@ dependencies = [
 [[package]]
 name = "sov-transaction-generator"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12018,7 +12020,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12030,7 +12032,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -12052,7 +12054,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "bech32",
  "borsh",
@@ -12067,7 +12069,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -12076,7 +12078,7 @@ dependencies = [
 [[package]]
 name = "sov-value-setter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12101,7 +12103,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,57 +22,57 @@ publish = false
 rust-version = "1.93"
 
 [workspace.dependencies]
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b", features = [
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2", features = [
   "evm",
 ] }
-sov-accounts = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-api-spec = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-attester-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-chain-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-bank = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-blob-storage = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-paymaster = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-capabilities = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-cli = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-hyperlane-integration = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b", features = [
+sov-accounts = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-api-spec = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-attester-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-chain-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-bank = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-blob-storage = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-paymaster = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-capabilities = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-cli = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-hyperlane-integration = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2", features = [
   "evm",
 ] }
-sov-eth-client = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-test-state-consistency = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-ledger-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-modules-rollup-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-uniqueness = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-operator-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-prover-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-revenue-share = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-rollup-full-node-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-sequencer = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-sequencer-registry = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-soak-testing-lib = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-stf-runner = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-test-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-rollup-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-universal-wallet = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-zkvm-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-build = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-ethereum = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-evm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-soak-testing = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-eip712-auth = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-rest-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-proxy-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b", features = ["native"] }
+sov-eth-client = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-test-state-consistency = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-ledger-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-modules-rollup-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-uniqueness = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-operator-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-prover-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-revenue-share = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-rollup-full-node-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-sequencer = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-sequencer-registry = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-soak-testing-lib = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-stf-runner = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-test-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-rollup-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-universal-wallet = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-zkvm-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-build = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-ethereum = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-evm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-soak-testing = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-eip712-auth = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-rest-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-proxy-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2", features = ["native"] }
 
 
 stf-starter = { path = "./crates/stf", default-features = false }

--- a/crates/provers/risc0/guest-celestia/Cargo.lock
+++ b/crates/provers/risc0/guest-celestia/Cargo.lock
@@ -2467,7 +2467,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 
 [[package]]
 name = "nmt-rs"
@@ -4071,7 +4071,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4085,7 +4085,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4103,7 +4103,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4122,7 +4122,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4141,7 +4141,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4160,7 +4160,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4171,7 +4171,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -4191,7 +4191,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4218,7 +4218,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4234,7 +4234,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "borsh",
  "derivative",
@@ -4268,7 +4268,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4283,7 +4283,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4319,7 +4319,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4340,7 +4340,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -4353,7 +4353,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4367,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4385,7 +4385,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4415,7 +4415,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4437,7 +4437,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4454,7 +4454,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4467,7 +4467,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4484,7 +4484,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4504,7 +4504,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4519,7 +4519,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4544,7 +4544,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4565,7 +4565,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4581,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4601,7 +4601,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4616,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4628,7 +4628,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4650,7 +4650,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "bech32",
  "borsh",
@@ -4665,7 +4665,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -4674,7 +4674,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/risc0/guest-celestia/Cargo.toml
+++ b/crates/provers/risc0/guest-celestia/Cargo.toml
@@ -12,16 +12,16 @@ anyhow = { version = "1.0.95" }
 risc0-zkvm = { version = "3.0", default-features = false, features = ["std"] }
 risc0-zkvm-platform = { version = "2.2" }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["celestia_da"] }
 

--- a/crates/provers/risc0/guest-mock/Cargo.lock
+++ b/crates/provers/risc0/guest-mock/Cargo.lock
@@ -2617,7 +2617,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 
 [[package]]
 name = "nmt-rs"
@@ -4236,7 +4236,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4250,7 +4250,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4268,7 +4268,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4287,7 +4287,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4306,7 +4306,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4325,7 +4325,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4336,7 +4336,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -4356,7 +4356,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4383,7 +4383,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4399,7 +4399,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "borsh",
  "derivative",
@@ -4413,7 +4413,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4428,7 +4428,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4464,7 +4464,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4485,7 +4485,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -4498,7 +4498,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4512,7 +4512,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4533,7 +4533,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4551,7 +4551,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4581,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4603,7 +4603,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4620,7 +4620,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4633,7 +4633,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4650,7 +4650,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4670,7 +4670,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4685,7 +4685,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4710,7 +4710,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4731,7 +4731,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4747,7 +4747,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4767,7 +4767,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4782,7 +4782,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4794,7 +4794,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4816,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "bech32",
  "borsh",
@@ -4831,7 +4831,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -4840,7 +4840,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/risc0/guest-mock/Cargo.toml
+++ b/crates/provers/risc0/guest-mock/Cargo.toml
@@ -15,16 +15,16 @@ risc0-zkvm-platform = { version = "2.2" }
 serde = { version = "1.0.188", features = ["derive", "rc"] }
 
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2", optional = true }
 
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["mock_da"] }

--- a/crates/provers/sp1/guest-celestia/Cargo.lock
+++ b/crates/provers/sp1/guest-celestia/Cargo.lock
@@ -3448,7 +3448,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 
 [[package]]
 name = "nmt-rs"
@@ -6100,7 +6100,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6114,7 +6114,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6132,7 +6132,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6151,7 +6151,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6170,7 +6170,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6189,7 +6189,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6200,7 +6200,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -6220,7 +6220,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6247,7 +6247,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6263,7 +6263,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "borsh",
  "derivative",
@@ -6296,7 +6296,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6311,7 +6311,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6347,7 +6347,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6368,7 +6368,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -6381,7 +6381,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6394,7 +6394,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6412,7 +6412,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6442,7 +6442,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6464,7 +6464,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6481,7 +6481,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6494,7 +6494,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6511,7 +6511,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6531,7 +6531,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6546,7 +6546,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6567,7 +6567,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6583,7 +6583,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6608,7 +6608,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6628,7 +6628,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6643,7 +6643,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6655,7 +6655,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -6677,7 +6677,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "bech32",
  "borsh",
@@ -6692,7 +6692,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -6701,7 +6701,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/sp1/guest-celestia/Cargo.toml
+++ b/crates/provers/sp1/guest-celestia/Cargo.toml
@@ -10,16 +10,16 @@ resolver = "2"
 anyhow = { version = "1.0.95" }
 sp1-zkvm = { version = "6.2.2" }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["celestia_da"] }
 

--- a/crates/provers/sp1/guest-mock/Cargo.lock
+++ b/crates/provers/sp1/guest-mock/Cargo.lock
@@ -3467,7 +3467,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 
 [[package]]
 name = "nmt-rs"
@@ -6119,7 +6119,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6133,7 +6133,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6151,7 +6151,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6170,7 +6170,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6189,7 +6189,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6208,7 +6208,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6219,7 +6219,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -6239,7 +6239,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6266,7 +6266,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6282,7 +6282,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "borsh",
  "derivative",
@@ -6296,7 +6296,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6311,7 +6311,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6347,7 +6347,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6368,7 +6368,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -6381,7 +6381,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6394,7 +6394,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6415,7 +6415,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6433,7 +6433,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6463,7 +6463,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6485,7 +6485,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6502,7 +6502,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6515,7 +6515,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6532,7 +6532,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6552,7 +6552,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6567,7 +6567,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6588,7 +6588,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6604,7 +6604,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6629,7 +6629,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6649,7 +6649,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6664,7 +6664,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6676,7 +6676,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -6698,7 +6698,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "bech32",
  "borsh",
@@ -6713,7 +6713,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet-macros"
 version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -6722,7 +6722,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=e9d6af29009115dffb2efcff5068423afa47f03b#e9d6af29009115dffb2efcff5068423afa47f03b"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/sp1/guest-mock/Cargo.toml
+++ b/crates/provers/sp1/guest-mock/Cargo.toml
@@ -10,16 +10,16 @@ resolver = "2"
 anyhow = { version = "1.0.95" }
 sp1-zkvm = { version = "6.2.2" }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "e9d6af29009115dffb2efcff5068423afa47f03b", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["mock_da"] }
 

--- a/crates/rollup/src/bin/mock_da.rs
+++ b/crates/rollup/src/bin/mock_da.rs
@@ -4,6 +4,7 @@ use tracing_subscriber::EnvFilter;
 use sov_mock_da::storable::rpc::start_server;
 use sov_mock_da::storable::StorableMockDaService;
 use sov_mock_da::{FailureBehavior, MockAddress, MockDaConfig};
+use sov_rollup_interface::node::SecondaryShutdownController;
 
 // Run with cargo run --bin mock-da-server --no-default-features --features="mock_da_external,mock_zkvm"
 #[derive(Parser, Debug)]
@@ -58,8 +59,9 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!("  Database: {}", cli.db);
     tracing::info!("  Block producing: {:?}", config.block_producing);
 
-    let (shutdown_sender, shutdown_receiver) = tokio::sync::watch::channel(());
-    let da_service = StorableMockDaService::from_config(config, shutdown_receiver).await;
+    let secondary_shutdown_controller = SecondaryShutdownController::new();
+    let da_service =
+        StorableMockDaService::from_config(config, &secondary_shutdown_controller).await;
     // Start the HTTP server
     let addr = start_server(da_service, &cli.host, cli.port).await?;
 
@@ -69,6 +71,6 @@ async fn main() -> anyhow::Result<()> {
     // Wait for shutdown signal
     tokio::signal::ctrl_c().await?;
     tracing::info!("Shutting down mock-da server...");
-    shutdown_sender.send(())?;
+    secondary_shutdown_controller.shutdown();
     Ok(())
 }

--- a/crates/rollup/src/da.rs
+++ b/crates/rollup/src/da.rs
@@ -8,8 +8,9 @@ mod celestia {
         types::Namespace,
         verifier::{CelestiaVerifier, RollupParams},
     };
-    use sov_modules_api::{prelude::tokio::sync::watch::Receiver, Spec};
+    use sov_modules_api::Spec;
     use sov_rollup_interface::da::DaVerifier;
+    use sov_rollup_interface::node::SecondaryShutdownController;
     use sov_stf_runner::RollupConfig;
 
     pub const ROLLUP_BATCH_NAMESPACE: Namespace =
@@ -27,7 +28,7 @@ mod celestia {
 
     pub async fn new_da_service<S: Spec>(
         rollup_config: &RollupConfig<S::Address, DaService>,
-        shutdown_receiver: Receiver<()>,
+        secondary_shutdown_controller: &SecondaryShutdownController,
     ) -> DaService {
         DaService::new(
             rollup_config.da.clone(),
@@ -35,7 +36,7 @@ mod celestia {
                 rollup_batch_namespace: ROLLUP_BATCH_NAMESPACE,
                 rollup_proof_namespace: ROLLUP_PROOF_NAMESPACE,
             },
-            shutdown_receiver,
+            secondary_shutdown_controller,
         )
         .await
     }
@@ -46,7 +47,8 @@ mod mock {
     pub use sov_mock_da::storable::local_service::StorableMockDaService as DaService;
     pub use sov_mock_da::MockDaSpec as DaSpec;
     use sov_mock_da::MockDaVerifier;
-    use sov_modules_api::{prelude::tokio::sync::watch::Receiver, Spec};
+    use sov_modules_api::Spec;
+    use sov_rollup_interface::node::SecondaryShutdownController;
     use sov_stf_runner::RollupConfig;
 
     pub fn new_verifier() -> MockDaVerifier {
@@ -55,9 +57,9 @@ mod mock {
 
     pub async fn new_da_service<S: Spec>(
         rollup_config: &RollupConfig<S::Address, DaService>,
-        shutdown_receiver: Receiver<()>,
+        secondary_shutdown_controller: &SecondaryShutdownController,
     ) -> DaService {
-        DaService::from_config(rollup_config.da.clone(), shutdown_receiver).await
+        DaService::from_config(rollup_config.da.clone(), secondary_shutdown_controller).await
     }
 }
 
@@ -66,7 +68,8 @@ mod mock_external {
     pub use sov_mock_da::storable::rpc::StorableMockDaClient as DaService;
     pub use sov_mock_da::MockDaSpec as DaSpec;
     use sov_mock_da::MockDaVerifier;
-    use sov_modules_api::{prelude::tokio::sync::watch::Receiver, Spec};
+    use sov_modules_api::Spec;
+    use sov_rollup_interface::node::SecondaryShutdownController;
     use sov_stf_runner::RollupConfig;
 
     pub fn new_verifier() -> MockDaVerifier {
@@ -75,7 +78,7 @@ mod mock_external {
 
     pub async fn new_da_service<S: Spec>(
         rollup_config: &RollupConfig<S::Address, DaService>,
-        _shutdown_receiver: Receiver<()>,
+        _secondary_shutdown_controller: &SecondaryShutdownController,
     ) -> DaService {
         DaService::from_config(rollup_config.da.clone())
             .expect("Failed to create DA service: Invalid URLs")

--- a/crates/rollup/src/rollup.rs
+++ b/crates/rollup/src/rollup.rs
@@ -122,9 +122,9 @@ impl FullNodeBlueprint<Native> for StarterRollup<Native> {
     async fn create_da_service(
         &self,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        secondary_shutdown_controller: &sov_rollup_interface::node::SecondaryShutdownController,
     ) -> Self::DaService {
-        new_da_service::<Self::Spec>(rollup_config, shutdown_receiver).await
+        new_da_service::<Self::Spec>(rollup_config, secondary_shutdown_controller).await
     }
 
     async fn create_prover_service(

--- a/crates/utils/node-discovery/Cargo.toml
+++ b/crates/utils/node-discovery/Cargo.toml
@@ -18,4 +18,5 @@ tracing-subscriber = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
 sov-metrics = { workspace = true }
+sov-rollup-interface = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/utils/node-discovery/src/main.rs
+++ b/crates/utils/node-discovery/src/main.rs
@@ -10,6 +10,7 @@ use sov_metrics::{init_metrics_tracker, MonitoringConfig};
 use sov_proxy_utils::{
     write_to_file_atomically, ClusterInfo, ClusterInfoService, ClusterUpdateNotifier,
 };
+use sov_rollup_interface::node::SecondaryShutdownController;
 use tokio::process::Command;
 
 struct ReloadNginx {
@@ -99,11 +100,10 @@ async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     tracing::info!("Starting node discovery.");
 
-    let (metrics_shutdown_sender, mut metrics_shutdown_receiver) = tokio::sync::watch::channel(());
-    metrics_shutdown_receiver.mark_unchanged();
+    let secondary_shutdown_controller = SecondaryShutdownController::new();
 
     let monitoring_config = MonitoringConfig::default_on_port(args.metrics_port);
-    init_metrics_tracker(&monitoring_config, metrics_shutdown_receiver.clone());
+    init_metrics_tracker(&monitoring_config, &secondary_shutdown_controller);
 
     let max_age = std::time::Duration::from_millis(args.max_age_millis);
 
@@ -124,10 +124,10 @@ async fn main() -> anyhow::Result<()> {
 
     if let Err(err) = cluster_info_service.join().await {
         tracing::error!(?err, "Failed to join cluster info service");
-        let _ = metrics_shutdown_sender.send(());
+        secondary_shutdown_controller.shutdown();
         exit(1);
     } else {
-        let _ = metrics_shutdown_sender.send(());
+        secondary_shutdown_controller.shutdown();
     }
 
     Ok(())


### PR DESCRIPTION
Upgrading to latest dev on 2026-06-23 b676f3df67a9c66124c225e384edecb5e26716f2

Breaking changes resolved:
- create_da_service (FullNodeBlueprint) now takes `&sov_rollup_interface::node::SecondaryShutdownController` instead of a `tokio::sync::watch::Receiver<()>` (SDK #3002). Updated the trait impl in rollup.rs and the `new_da_service` helpers in da.rs; `StorableMockDaService::from_config` and `CelestiaService::new` now take `&SecondaryShutdownController`.
- `sov_metrics::init_metrics_tracker` now takes `&SecondaryShutdownController` instead of `Receiver<()>`. Updated the node-discovery binary to construct a controller and call `.shutdown()`; added a `sov-rollup-interface` dependency.
- `bin/mock_da.rs` constructs a `SecondaryShutdownController` and calls `.shutdown()` on Ctrl-C.