### PR TITLE
Update to the latest dev 2026-06-24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6060,6 +6060,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+
+[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6424,7 +6430,7 @@ dependencies = [
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 
 [[package]]
 name = "nix"
@@ -6465,7 +6471,7 @@ dependencies = [
  "clap",
  "sov-metrics",
  "sov-proxy-utils",
- "sov-rollup-interface",
+ "sov-shutdown",
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.23",
@@ -9191,6 +9197,7 @@ dependencies = [
  "sov-rollup-interface",
  "sov-sequencer",
  "sov-sequencer-registry",
+ "sov-shutdown",
  "sov-sp1-adapter",
  "sov-state",
  "sov-stf-runner",
@@ -10724,7 +10731,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -10739,7 +10746,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -10760,7 +10767,7 @@ dependencies = [
 [[package]]
 name = "sov-api-spec"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "backon",
@@ -10784,7 +10791,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10804,7 +10811,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10824,7 +10831,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-sender"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10838,6 +10845,7 @@ dependencies = [
  "sov-metrics",
  "sov-modules-api",
  "sov-rollup-interface",
+ "sov-shutdown",
  "tokio",
  "tracing",
  "uuid",
@@ -10846,7 +10854,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10865,7 +10873,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10876,7 +10884,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -10896,7 +10904,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -10909,6 +10917,7 @@ dependencies = [
  "derive_more 2.1.1",
  "futures",
  "hex",
+ "lz4_flex",
  "nmt-rs",
  "proptest",
  "prost 0.13.5",
@@ -10919,6 +10928,7 @@ dependencies = [
  "sov-metrics",
  "sov-modules-macros",
  "sov-rollup-interface",
+ "sov-shutdown",
  "sov-universal-wallet",
  "tendermint",
  "tendermint-proto",
@@ -10930,7 +10940,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10947,7 +10957,7 @@ dependencies = [
 [[package]]
 name = "sov-cli"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -10970,7 +10980,7 @@ dependencies = [
 [[package]]
 name = "sov-db"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11002,7 +11012,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -11020,7 +11030,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11035,7 +11045,7 @@ dependencies = [
 [[package]]
 name = "sov-eth-client"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -11062,7 +11072,7 @@ dependencies = [
 [[package]]
 name = "sov-eth-dev-signer"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11073,7 +11083,7 @@ dependencies = [
 [[package]]
 name = "sov-ethereum"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11093,8 +11103,10 @@ dependencies = [
  "sov-modules-api",
  "sov-modules-stf-blueprint",
  "sov-rest-utils",
+ "sov-rollup-interface",
  "sov-rpc-eth-types",
  "sov-sequencer",
+ "sov-shutdown",
  "sov-uniqueness",
  "thiserror 2.0.18",
  "tokio",
@@ -11104,7 +11116,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11145,7 +11157,7 @@ dependencies = [
 [[package]]
 name = "sov-evm-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -11161,7 +11173,7 @@ dependencies = [
 [[package]]
 name = "sov-full-node-configs"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -11176,7 +11188,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11200,7 +11212,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -11213,7 +11225,7 @@ dependencies = [
 [[package]]
 name = "sov-ledger-apis"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11227,6 +11239,7 @@ dependencies = [
  "sov-modules-api",
  "sov-rest-utils",
  "sov-rollup-interface",
+ "sov-shutdown",
  "tokio",
  "tracing",
 ]
@@ -11234,7 +11247,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -11247,7 +11260,7 @@ dependencies = [
  "risc0-zkvm-platform",
  "schemars 1.2.1",
  "serde",
- "sov-rollup-interface",
+ "sov-shutdown",
  "sp1-lib",
  "tokio",
  "tokio-metrics",
@@ -11257,7 +11270,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11280,6 +11293,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "sov-rollup-interface",
+ "sov-shutdown",
  "sov-universal-wallet",
  "sqlx",
  "tokio",
@@ -11291,7 +11305,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11311,7 +11325,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11342,6 +11356,7 @@ dependencies = [
  "sov-modules-macros",
  "sov-rest-utils",
  "sov-rollup-interface",
+ "sov-shutdown",
  "sov-state",
  "sov-universal-wallet",
  "strum 0.28.0",
@@ -11358,7 +11373,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "bech32",
@@ -11380,7 +11395,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-rollup-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11407,6 +11422,7 @@ dependencies = [
  "sov-rollup-full-node-interface",
  "sov-rollup-interface",
  "sov-sequencer",
+ "sov-shutdown",
  "sov-state",
  "sov-stf-runner",
  "tokio",
@@ -11420,7 +11436,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11437,7 +11453,7 @@ dependencies = [
 [[package]]
 name = "sov-node-client"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -11456,7 +11472,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11469,7 +11485,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11486,7 +11502,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11506,7 +11522,7 @@ dependencies = [
 [[package]]
 name = "sov-proxy-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11523,7 +11539,7 @@ dependencies = [
 [[package]]
 name = "sov-rest-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -11536,6 +11552,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sov-shutdown",
  "thiserror 2.0.18",
  "tokio",
  "tower 0.5.3",
@@ -11547,7 +11564,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11562,7 +11579,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11590,7 +11607,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-apis"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "axum 0.8.8",
  "borsh",
@@ -11611,7 +11628,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-full-node-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "derive_more 2.1.1",
  "rockbound",
@@ -11623,7 +11640,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11669,7 +11686,7 @@ dependencies = [
 [[package]]
 name = "sov-rpc-eth-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11689,7 +11706,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11721,6 +11738,7 @@ dependencies = [
  "sov-rest-utils",
  "sov-rollup-full-node-interface",
  "sov-rollup-interface",
+ "sov-shutdown",
  "sov-state",
  "sov-uniqueness",
  "sqlx",
@@ -11736,7 +11754,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11749,6 +11767,15 @@ dependencies = [
  "sov-modules-api",
  "sov-state",
  "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "sov-shutdown"
+version = "0.3.0"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
+dependencies = [
+ "tokio",
  "tracing",
 ]
 
@@ -11769,7 +11796,7 @@ dependencies = [
 [[package]]
 name = "sov-soak-testing-lib"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "clap",
@@ -11787,7 +11814,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11817,7 +11844,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -11842,7 +11869,7 @@ dependencies = [
 [[package]]
 name = "sov-stf-runner"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11865,6 +11892,7 @@ dependencies = [
  "sov-rest-utils",
  "sov-rollup-full-node-interface",
  "sov-rollup-interface",
+ "sov-shutdown",
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
@@ -11877,7 +11905,7 @@ dependencies = [
 [[package]]
 name = "sov-synthetic-load"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11893,7 +11921,7 @@ dependencies = [
 [[package]]
 name = "sov-test-modules"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11911,7 +11939,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -11926,7 +11954,7 @@ dependencies = [
 [[package]]
 name = "sov-test-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11968,6 +11996,7 @@ dependencies = [
  "sov-rollup-interface",
  "sov-sequencer",
  "sov-sequencer-registry",
+ "sov-shutdown",
  "sov-state",
  "sov-stf-runner",
  "sov-uniqueness",
@@ -11987,7 +12016,7 @@ dependencies = [
 [[package]]
 name = "sov-transaction-generator"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12020,7 +12049,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12031,8 +12060,8 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet"
-version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+version = "0.4.1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -12053,8 +12082,8 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
-version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+version = "0.4.1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "bech32",
  "borsh",
@@ -12068,8 +12097,8 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macros"
-version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+version = "0.4.1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -12078,7 +12107,7 @@ dependencies = [
 [[package]]
 name = "sov-value-setter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -12103,7 +12132,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,57 +22,58 @@ publish = false
 rust-version = "1.93"
 
 [workspace.dependencies]
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2", features = [
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6", features = [
   "evm",
 ] }
-sov-accounts = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-api-spec = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-attester-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-chain-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-bank = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-blob-storage = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-paymaster = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-capabilities = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-cli = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-hyperlane-integration = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2", features = [
+sov-accounts = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-api-spec = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-attester-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-chain-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-bank = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-blob-storage = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-paymaster = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-capabilities = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-cli = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-db = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-hyperlane-integration = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6", features = [
   "evm",
 ] }
-sov-eth-client = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-test-state-consistency = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-ledger-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-modules-rollup-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-uniqueness = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-operator-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-prover-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-revenue-share = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-rollup-full-node-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-sequencer = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-sequencer-registry = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-soak-testing-lib = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-stf-runner = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-test-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-rollup-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-universal-wallet = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-zkvm-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-build = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-ethereum = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-evm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-soak-testing = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-eip712-auth = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-rest-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-proxy-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2", features = ["native"] }
+sov-eth-client = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-test-state-consistency = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-ledger-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-modules-rollup-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-uniqueness = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-operator-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-prover-incentives = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-revenue-share = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-shutdown = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-rollup-full-node-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-sequencer = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-sequencer-registry = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-soak-testing-lib = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-stf-runner = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-test-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-rollup-apis = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-universal-wallet = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-zkvm-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-build = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-ethereum = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-evm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-soak-testing = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-eip712-auth = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-rest-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-proxy-utils = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6", features = ["native"] }
 
 
 stf-starter = { path = "./crates/stf", default-features = false }

--- a/constants.toml
+++ b/constants.toml
@@ -32,6 +32,21 @@ BATCH_NAMESPACE = { byte_string = "test_1xx-b" }
 # Should be 10 bytes long for Celestia
 PROOF_NAMESPACE = { byte_string = "test_1xx-p" }
 
+# Celestia compression — max UNCOMPRESSED (decoded) bytes in one envelope chunk: 16 KiB.
+# This is the decompression-bomb bound: the verifier allocates at most this many bytes per
+# chunk and rejects any chunk claiming to decode larger. Consensus-relevant — every reader
+# (native node + ZK guest) compiled for a deployment must agree; only change it before
+# compression is ever emitted on a live network. Must fit u16 and stay well below 65535.
+CELESTIA_MAX_ROLLUP_CHUNK_LEN = { const = 16384 }
+# Celestia compression — max COMPRESSED (on-DA) bytes in one envelope chunk: sized so a single
+# chunk never spills past the FIRST Celestia share. Bounds how many shares a single chunk read
+# forces the prover to authenticate in ZK (DoS protection against spam that overloads the prover).
+# 430 = one signed-v1 first share (458 payload bytes) minus the 24-byte envelope header minus the
+# 4-byte chunk header. Conservative: the first chunk is the tightest (it follows the envelope
+# header), so capping it here keeps a chunk read to a single authenticated share. Consensus-relevant
+# — same rules as above.
+CELESTIA_MAX_COMPRESSED_CHUNK_SIZE = { const = 430 }
+
 # The number of bytes a transaction can have.
 MAX_TX_SIZE=1_048_576
 EVM_GAS_METERING_MODE = "Rollup"

--- a/crates/provers/risc0/guest-celestia/Cargo.lock
+++ b/crates/provers/risc0/guest-celestia/Cargo.lock
@@ -2352,6 +2352,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+
+[[package]]
 name = "macro-string"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2467,7 +2473,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 
 [[package]]
 name = "nmt-rs"
@@ -4071,7 +4077,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4085,7 +4091,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4103,7 +4109,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4122,7 +4128,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4141,7 +4147,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4160,7 +4166,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4171,7 +4177,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -4191,7 +4197,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4200,6 +4206,7 @@ dependencies = [
  "celestia-types",
  "derive_more",
  "hex",
+ "lz4_flex",
  "nmt-rs",
  "prost",
  "schemars 1.2.1",
@@ -4218,7 +4225,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4234,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "borsh",
  "derivative",
@@ -4268,7 +4275,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4283,7 +4290,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4319,7 +4326,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4340,7 +4347,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -4353,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4367,7 +4374,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4385,7 +4392,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4415,7 +4422,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4437,7 +4444,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4454,7 +4461,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4467,7 +4474,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4484,7 +4491,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4504,7 +4511,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4519,7 +4526,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4544,7 +4551,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4565,7 +4572,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4581,7 +4588,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4601,7 +4608,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4616,7 +4623,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4627,8 +4634,8 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet"
-version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+version = "0.4.1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4649,8 +4656,8 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
-version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+version = "0.4.1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "bech32",
  "borsh",
@@ -4664,8 +4671,8 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macros"
-version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+version = "0.4.1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -4674,7 +4681,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/risc0/guest-celestia/Cargo.toml
+++ b/crates/provers/risc0/guest-celestia/Cargo.toml
@@ -12,16 +12,16 @@ anyhow = { version = "1.0.95" }
 risc0-zkvm = { version = "3.0", default-features = false, features = ["std"] }
 risc0-zkvm-platform = { version = "2.2" }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["celestia_da"] }
 

--- a/crates/provers/risc0/guest-mock/Cargo.lock
+++ b/crates/provers/risc0/guest-mock/Cargo.lock
@@ -2502,6 +2502,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+
+[[package]]
 name = "macro-string"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2617,7 +2623,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 
 [[package]]
 name = "nmt-rs"
@@ -4236,7 +4242,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4250,7 +4256,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -4268,7 +4274,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4287,7 +4293,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4306,7 +4312,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4325,7 +4331,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4336,7 +4342,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -4356,7 +4362,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4365,6 +4371,7 @@ dependencies = [
  "celestia-types",
  "derive_more",
  "hex",
+ "lz4_flex",
  "nmt-rs",
  "prost",
  "schemars 1.2.1",
@@ -4383,7 +4390,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4399,7 +4406,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "borsh",
  "derivative",
@@ -4413,7 +4420,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4428,7 +4435,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4464,7 +4471,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4485,7 +4492,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -4498,7 +4505,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4512,7 +4519,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4533,7 +4540,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4551,7 +4558,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4581,7 +4588,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4603,7 +4610,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4620,7 +4627,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4633,7 +4640,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4650,7 +4657,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4670,7 +4677,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4685,7 +4692,7 @@ dependencies = [
 [[package]]
 name = "sov-risc0-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4710,7 +4717,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4731,7 +4738,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4747,7 +4754,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4767,7 +4774,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4782,7 +4789,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4793,8 +4800,8 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet"
-version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+version = "0.4.1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -4815,8 +4822,8 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
-version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+version = "0.4.1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "bech32",
  "borsh",
@@ -4830,8 +4837,8 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macros"
-version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+version = "0.4.1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -4840,7 +4847,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/risc0/guest-mock/Cargo.toml
+++ b/crates/provers/risc0/guest-mock/Cargo.toml
@@ -15,16 +15,16 @@ risc0-zkvm-platform = { version = "2.2" }
 serde = { version = "1.0.188", features = ["derive", "rc"] }
 
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-risc0-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6", optional = true }
 
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["mock_da"] }

--- a/crates/provers/sp1/guest-celestia/Cargo.lock
+++ b/crates/provers/sp1/guest-celestia/Cargo.lock
@@ -3274,6 +3274,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+
+[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3448,7 +3454,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 
 [[package]]
 name = "nmt-rs"
@@ -6100,7 +6106,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6114,7 +6120,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6132,7 +6138,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6151,7 +6157,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6170,7 +6176,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6189,7 +6195,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6200,7 +6206,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -6220,7 +6226,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6229,6 +6235,7 @@ dependencies = [
  "celestia-types",
  "derive_more 2.1.1",
  "hex",
+ "lz4_flex",
  "nmt-rs",
  "prost",
  "schemars 1.2.1",
@@ -6247,7 +6254,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6263,7 +6270,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "borsh",
  "derivative",
@@ -6296,7 +6303,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6311,7 +6318,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6347,7 +6354,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6368,7 +6375,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -6381,7 +6388,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6394,7 +6401,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6412,7 +6419,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6442,7 +6449,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6464,7 +6471,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6481,7 +6488,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6494,7 +6501,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6511,7 +6518,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6531,7 +6538,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6546,7 +6553,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6567,7 +6574,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6583,7 +6590,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6608,7 +6615,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6628,7 +6635,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6643,7 +6650,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6654,8 +6661,8 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet"
-version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+version = "0.4.1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -6676,8 +6683,8 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
-version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+version = "0.4.1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "bech32",
  "borsh",
@@ -6691,8 +6698,8 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macros"
-version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+version = "0.4.1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -6701,7 +6708,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/sp1/guest-celestia/Cargo.toml
+++ b/crates/provers/sp1/guest-celestia/Cargo.toml
@@ -10,16 +10,16 @@ resolver = "2"
 anyhow = { version = "1.0.95" }
 sp1-zkvm = { version = "6.2.2" }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-celestia-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["celestia_da"] }
 

--- a/crates/provers/sp1/guest-mock/Cargo.lock
+++ b/crates/provers/sp1/guest-mock/Cargo.lock
@@ -3293,6 +3293,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+
+[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3467,7 +3473,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 [[package]]
 name = "nearly-linear"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 
 [[package]]
 name = "nmt-rs"
@@ -6119,7 +6125,7 @@ dependencies = [
 [[package]]
 name = "sov-accounts"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6133,7 +6139,7 @@ dependencies = [
 [[package]]
 name = "sov-address"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "alloy-primitives",
  "anyhow",
@@ -6151,7 +6157,7 @@ dependencies = [
 [[package]]
 name = "sov-attester-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6170,7 +6176,7 @@ dependencies = [
 [[package]]
 name = "sov-bank"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6189,7 +6195,7 @@ dependencies = [
 [[package]]
 name = "sov-blob-storage"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6208,7 +6214,7 @@ dependencies = [
 [[package]]
 name = "sov-build"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6219,7 +6225,7 @@ dependencies = [
 [[package]]
 name = "sov-capabilities"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "sov-accounts",
@@ -6239,7 +6245,7 @@ dependencies = [
 [[package]]
 name = "sov-celestia-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6248,6 +6254,7 @@ dependencies = [
  "celestia-types",
  "derive_more 2.1.1",
  "hex",
+ "lz4_flex",
  "nmt-rs",
  "prost",
  "schemars 1.2.1",
@@ -6266,7 +6273,7 @@ dependencies = [
 [[package]]
 name = "sov-chain-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6282,7 +6289,7 @@ dependencies = [
 [[package]]
 name = "sov-db-types"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "borsh",
  "derivative",
@@ -6296,7 +6303,7 @@ dependencies = [
 [[package]]
 name = "sov-eip712-auth"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6311,7 +6318,7 @@ dependencies = [
 [[package]]
 name = "sov-evm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6347,7 +6354,7 @@ dependencies = [
 [[package]]
 name = "sov-hyperlane-integration"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6368,7 +6375,7 @@ dependencies = [
 [[package]]
 name = "sov-kernels"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "sov-blob-storage",
@@ -6381,7 +6388,7 @@ dependencies = [
 [[package]]
 name = "sov-metrics"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6394,7 +6401,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-da"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6415,7 +6422,7 @@ dependencies = [
 [[package]]
 name = "sov-mock-zkvm"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6433,7 +6440,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-api"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6463,7 +6470,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-macros"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "bech32",
@@ -6485,7 +6492,7 @@ dependencies = [
 [[package]]
 name = "sov-modules-stf-blueprint"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6502,7 +6509,7 @@ dependencies = [
 [[package]]
 name = "sov-operator-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6515,7 +6522,7 @@ dependencies = [
 [[package]]
 name = "sov-paymaster"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6532,7 +6539,7 @@ dependencies = [
 [[package]]
 name = "sov-prover-incentives"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6552,7 +6559,7 @@ dependencies = [
 [[package]]
 name = "sov-revenue-share"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6567,7 +6574,7 @@ dependencies = [
 [[package]]
 name = "sov-rollup-interface"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6588,7 +6595,7 @@ dependencies = [
 [[package]]
 name = "sov-sequencer-registry"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6604,7 +6611,7 @@ dependencies = [
 [[package]]
 name = "sov-sp1-adapter"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -6629,7 +6636,7 @@ dependencies = [
 [[package]]
 name = "sov-state"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6649,7 +6656,7 @@ dependencies = [
 [[package]]
 name = "sov-test-state-consistency"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6664,7 +6671,7 @@ dependencies = [
 [[package]]
 name = "sov-uniqueness"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6675,8 +6682,8 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet"
-version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+version = "0.4.1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -6697,8 +6704,8 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macro-helpers"
-version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+version = "0.4.1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "bech32",
  "borsh",
@@ -6712,8 +6719,8 @@ dependencies = [
 
 [[package]]
 name = "sov-universal-wallet-macros"
-version = "0.4.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+version = "0.4.1"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "sov-universal-wallet-macro-helpers",
  "syn 2.0.117",
@@ -6722,7 +6729,7 @@ dependencies = [
 [[package]]
 name = "sov-zkvm-utils"
 version = "0.3.0"
-source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=b676f3df67a9c66124c225e384edecb5e26716f2#b676f3df67a9c66124c225e384edecb5e26716f2"
+source = "git+https://github.com/Sovereign-Labs/sovereign-sdk.git?rev=878ac1de06ffe337a984fcd03c0196223b3faed6#878ac1de06ffe337a984fcd03c0196223b3faed6"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",

--- a/crates/provers/sp1/guest-mock/Cargo.toml
+++ b/crates/provers/sp1/guest-mock/Cargo.toml
@@ -10,16 +10,16 @@ resolver = "2"
 anyhow = { version = "1.0.95" }
 sp1-zkvm = { version = "6.2.2" }
 
-sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2", features = ["evm"] }
-sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2" }
-sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "b676f3df67a9c66124c225e384edecb5e26716f2", optional = true }
+sov-address = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6", features = ["evm"] }
+sov-rollup-interface = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-mock-da = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-modules-stf-blueprint = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-modules-api = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-sp1-adapter = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-state = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-mock-zkvm = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-kernels = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6" }
+sov-metrics = { git = "https://github.com/Sovereign-Labs/sovereign-sdk.git", rev = "878ac1de06ffe337a984fcd03c0196223b3faed6", optional = true }
 
 stf-starter = { path = "../../../stf", default-features = false, features = ["mock_da"] }
 

--- a/crates/rollup/Cargo.toml
+++ b/crates/rollup/Cargo.toml
@@ -33,6 +33,7 @@ sov-sequencer = { workspace = true }
 sov-rest-utils = { workspace = true }
 sov-eip712-auth = { workspace = true }
 sov-rollup-interface = { workspace = true }
+sov-shutdown = { workspace = true }
 sov-rollup-full-node-interface = { workspace = true }
 sov-mock-da = { workspace = true, features = ["native"], optional = true }
 sov-celestia-adapter = { workspace = true, features = ["native"], optional = true }

--- a/crates/rollup/src/bin/mock_da.rs
+++ b/crates/rollup/src/bin/mock_da.rs
@@ -4,7 +4,7 @@ use tracing_subscriber::EnvFilter;
 use sov_mock_da::storable::rpc::start_server;
 use sov_mock_da::storable::StorableMockDaService;
 use sov_mock_da::{FailureBehavior, MockAddress, MockDaConfig};
-use sov_rollup_interface::node::SecondaryShutdownController;
+use sov_shutdown::SecondaryShutdownController;
 
 // Run with cargo run --bin mock-da-server --no-default-features --features="mock_da_external,mock_zkvm"
 #[derive(Parser, Debug)]

--- a/crates/rollup/src/da.rs
+++ b/crates/rollup/src/da.rs
@@ -10,7 +10,7 @@ mod celestia {
     };
     use sov_modules_api::Spec;
     use sov_rollup_interface::da::DaVerifier;
-    use sov_rollup_interface::node::SecondaryShutdownController;
+    use sov_shutdown::SecondaryShutdownController;
     use sov_stf_runner::RollupConfig;
 
     pub const ROLLUP_BATCH_NAMESPACE: Namespace =
@@ -48,7 +48,7 @@ mod mock {
     pub use sov_mock_da::MockDaSpec as DaSpec;
     use sov_mock_da::MockDaVerifier;
     use sov_modules_api::Spec;
-    use sov_rollup_interface::node::SecondaryShutdownController;
+    use sov_shutdown::SecondaryShutdownController;
     use sov_stf_runner::RollupConfig;
 
     pub fn new_verifier() -> MockDaVerifier {
@@ -69,7 +69,7 @@ mod mock_external {
     pub use sov_mock_da::MockDaSpec as DaSpec;
     use sov_mock_da::MockDaVerifier;
     use sov_modules_api::Spec;
-    use sov_rollup_interface::node::SecondaryShutdownController;
+    use sov_shutdown::SecondaryShutdownController;
     use sov_stf_runner::RollupConfig;
 
     pub fn new_verifier() -> MockDaVerifier {

--- a/crates/rollup/src/rollup.rs
+++ b/crates/rollup/src/rollup.rs
@@ -36,6 +36,7 @@ use sov_rollup_interface::zk::aggregated_proof::{
 };
 use sov_rollup_interface::zk::ZkVerifier;
 use sov_sequencer::{ProofBlobSender, SeqConfigExtension, Sequencer, TxStatus};
+use sov_shutdown::{PrimaryShutdownController, SecondaryShutdownController};
 use sov_state::nomt::prover_storage::NomtProverStorage;
 use sov_state::DefaultStorageSpec;
 use sov_state::Storage;
@@ -102,7 +103,7 @@ impl FullNodeBlueprint<Native> for StarterRollup<Native> {
         &self,
         state_update_receiver: StateUpdateReceiver<<Self::Spec as Spec>::Storage>,
         sync_status_receiver: watch::Receiver<SyncStatus>,
-        shutdown_receiver: watch::Receiver<()>,
+        primary_shutdown: PrimaryShutdownController,
         ledger_db: &LedgerDb,
         sequencer: &SequencerCreationReceipt<Self::Spec>,
         _da_service: &Self::DaService,
@@ -111,7 +112,7 @@ impl FullNodeBlueprint<Native> for StarterRollup<Native> {
         sov_modules_rollup_blueprint::register_endpoints::<Self, _>(
             state_update_receiver.clone(),
             sync_status_receiver,
-            shutdown_receiver,
+            primary_shutdown,
             ledger_db,
             sequencer,
             rollup_config,
@@ -122,7 +123,7 @@ impl FullNodeBlueprint<Native> for StarterRollup<Native> {
     async fn create_da_service(
         &self,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
-        secondary_shutdown_controller: &sov_rollup_interface::node::SecondaryShutdownController,
+        secondary_shutdown_controller: &SecondaryShutdownController,
     ) -> Self::DaService {
         new_da_service::<Self::Spec>(rollup_config, secondary_shutdown_controller).await
     }
@@ -204,7 +205,7 @@ impl FullNodeBlueprint<Native> for StarterRollup<Native> {
         &self,
         sequencer: Seq,
         rollup_config: &RollupConfig<<Self::Spec as Spec>::Address, Self::DaService>,
-        shutdown_receiver: tokio::sync::watch::Receiver<()>,
+        primary_shutdown: PrimaryShutdownController,
         sequencer_da_address: <<Self::Spec as Spec>::Da as sov_rollup_interface::da::DaSpec>::Address,
     ) -> anyhow::Result<sov_modules_api::NodeEndpoints>
     where
@@ -219,7 +220,7 @@ impl FullNodeBlueprint<Native> for StarterRollup<Native> {
             sequencer_rollup_address: rollup_config.sequencer.rollup_address,
             sequencer_da_address,
             sequencer_type: SequencerType::Preferred,
-            shutdown_receiver,
+            primary_shutdown,
         };
 
         let axum_router = axum::Router::new()
@@ -230,7 +231,6 @@ impl FullNodeBlueprint<Native> for StarterRollup<Native> {
             axum_router,
             jsonrpsee_module: sov_ethereum::get_ethereum_rpc(eth_rpc_config, sequencer)
                 .remove_context(),
-            ..Default::default()
         })
     }
 }

--- a/crates/stf/src/runtime.rs
+++ b/crates/stf/src/runtime.rs
@@ -81,7 +81,6 @@ where
         sov_modules_api::NodeEndpoints {
             axum_router,
             jsonrpsee_module: stf_starter_declaration::get_rpc_methods::<S>(api_state),
-            background_handles: Vec::new(),
         }
     }
 

--- a/crates/utils/node-discovery/Cargo.toml
+++ b/crates/utils/node-discovery/Cargo.toml
@@ -18,5 +18,5 @@ tracing-subscriber = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
 sov-metrics = { workspace = true }
-sov-rollup-interface = { workspace = true }
+sov-shutdown = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/utils/node-discovery/src/main.rs
+++ b/crates/utils/node-discovery/src/main.rs
@@ -10,7 +10,7 @@ use sov_metrics::{init_metrics_tracker, MonitoringConfig};
 use sov_proxy_utils::{
     write_to_file_atomically, ClusterInfo, ClusterInfoService, ClusterUpdateNotifier,
 };
-use sov_rollup_interface::node::SecondaryShutdownController;
+use sov_shutdown::SecondaryShutdownController;
 use tokio::process::Command;
 
 struct ReloadNginx {


### PR DESCRIPTION
Upgrading to latest dev on 2026-06-24 292443b61476711760a77df1b43914727877145f

Breaking changes resolved:
- #3011 Primary shutdown controller: FullNodeBlueprint::create_endpoints and sequencer_additional_apis now take `primary_shutdown: sov_rollup_interface::node::PrimaryShutdownController` instead of `shutdown_receiver: watch::Receiver<()>`. Updated both methods in crates/rollup/src/rollup.rs; EthRpcConfig's field was likewise renamed to `primary_shutdown`.
- #2989 Celestia compression: added two consensus-relevant constants (CELESTIA_MAX_ROLLUP_CHUNK_LEN = 16384, CELESTIA_MAX_COMPRESSED_CHUNK_SIZE = 430) to constants.toml and scripts/acceptance-test/constants.testing.toml. Compression is emission-only and defaults to off; no config changes required.
- #3014 Celestia config now uses serde(deny_unknown_fields) and lowercase enum casing for tx_priority/compression. Our [da] config fields are all valid and we set neither enum, so no config changes were needed.