### PR TITLE
Subsecond improvements + Stork provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6068,6 +6068,7 @@ dependencies = [
  "clap",
  "futures",
  "hex",
+ "parking_lot",
  "price-oracle",
  "price-oracle-ipc",
  "rand 0.8.5",

--- a/configs/celestia/oracle.toml
+++ b/configs/celestia/oracle.toml
@@ -4,15 +4,18 @@ require_sources = false
 
 [[oracle.source]]
 name = "chainlink-1"
+provider_id = "chainlink"
 socket_address = "127.0.0.1:9801"
 transport = "tcp"
 
 [[oracle.source]]
 name = "chainlink-2"
+provider_id = "chainlink"
 socket_address = "127.0.0.1:9802"
 transport = "tcp"
 
 [[oracle.source]]
 name = "chainlink-3"
+provider_id = "chainlink"
 socket_address = "127.0.0.1:9803"
 transport = "tcp"

--- a/configs/celestia/oracle.toml
+++ b/configs/celestia/oracle.toml
@@ -4,18 +4,15 @@ require_sources = false
 
 [[oracle.source]]
 name = "chainlink-1"
-provider_id = "chainlink"
-socket_address = "127.0.0.1:9801"
-transport = "tcp"
+provider = "chainlink"
+address = "127.0.0.1:9801"
 
 [[oracle.source]]
 name = "chainlink-2"
-provider_id = "chainlink"
-socket_address = "127.0.0.1:9802"
-transport = "tcp"
+provider = "chainlink"
+address = "127.0.0.1:9802"
 
 [[oracle.source]]
 name = "chainlink-3"
-provider_id = "chainlink"
-socket_address = "127.0.0.1:9803"
-transport = "tcp"
+provider = "chainlink"
+address = "127.0.0.1:9803"

--- a/configs/celestia/oracle.toml
+++ b/configs/celestia/oracle.toml
@@ -3,16 +3,16 @@ enabled = true
 require_sources = false
 
 [[oracle.source]]
-name = "chainlink-1"
-provider = "chainlink"
+name = "stork-1"
+provider = "stork"
 address = "127.0.0.1:9801"
 
 [[oracle.source]]
-name = "chainlink-2"
-provider = "chainlink"
+name = "stork-2"
+provider = "stork"
 address = "127.0.0.1:9802"
 
 [[oracle.source]]
-name = "chainlink-3"
-provider = "chainlink"
+name = "stork-3"
+provider = "stork"
 address = "127.0.0.1:9803"

--- a/crates/precompiles/price-oracle/src/prices.rs
+++ b/crates/precompiles/price-oracle/src/prices.rs
@@ -49,7 +49,7 @@ impl OracleStore {
         provider_id: B256,
         feed_id: B256,
         payload: Vec<u8>,
-        order_time: u64,
+        payload_time_ms: u64,
     ) -> InsertOutcome {
         let allowed = self
             .allowed_feeds
@@ -60,11 +60,11 @@ impl OracleStore {
         }
         let key = FeedKey::new(provider_id, feed_id);
         if let Some((_, existing_time)) = self.reports.get(&key) {
-            if *existing_time >= order_time {
+            if *existing_time >= payload_time_ms {
                 return InsertOutcome::Stale;
             }
         }
-        self.reports.insert(key, (Bytes::from(payload), order_time));
+        self.reports.insert(key, (Bytes::from(payload), payload_time_ms));
         InsertOutcome::Inserted
     }
 
@@ -147,11 +147,11 @@ pub fn insert_if_newer(
     provider_id: B256,
     feed_id: B256,
     payload: Vec<u8>,
-    order_time: u64,
+    payload_time_ms: u64,
 ) -> InsertOutcome {
     ORACLE_STORE
         .write()
-        .insert_if_newer(provider_id, feed_id, payload, order_time)
+        .insert_if_newer(provider_id, feed_id, payload, payload_time_ms)
 }
 
 pub fn register_feeds(source_name: &str, provider_id: B256, feeds: Vec<B256>) -> RegisterOutcome {

--- a/crates/precompiles/price-oracle/src/prices.rs
+++ b/crates/precompiles/price-oracle/src/prices.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::LazyLock;
+use std::time::{Duration, Instant};
 
 use bytes::Bytes;
 use parking_lot::RwLock;
@@ -12,6 +13,8 @@ static ORACLE_STORE: LazyLock<RwLock<OracleStore>> =
 #[derive(Debug, PartialEq, Eq)]
 pub enum InsertOutcome {
     Inserted,
+    Duplicate,
+    Conflict,
     Stale,
     Unexpected,
 }
@@ -19,7 +22,7 @@ pub enum InsertOutcome {
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct RegisterOutcome {
     pub evicted: usize,
-    pub feeds_diverged: bool,
+    pub feed_set_conflicts: Vec<B256>,
 }
 
 struct SourceFeeds {
@@ -27,9 +30,15 @@ struct SourceFeeds {
     feeds: BTreeSet<B256>,
 }
 
+struct Report {
+    payload: Bytes,
+    source_time_ms: u64,
+    updated: Instant,
+}
+
 #[derive(Default)]
 struct OracleStore {
-    reports: BTreeMap<FeedKey, (Bytes, u64)>,
+    reports: BTreeMap<FeedKey, Report>,
     source_feeds: BTreeMap<String, SourceFeeds>,
     allowed_feeds: BTreeMap<B256, BTreeSet<B256>>,
 }
@@ -39,7 +48,7 @@ impl OracleStore {
         PriceReports(
             self.reports
                 .iter()
-                .map(|(key, (payload, _))| (*key, payload.clone()))
+                .map(|(key, report)| (*key, report.payload.clone()))
                 .collect(),
         )
     }
@@ -49,7 +58,7 @@ impl OracleStore {
         provider_id: B256,
         feed_id: B256,
         payload: Vec<u8>,
-        payload_time_ms: u64,
+        source_time_ms: u64,
     ) -> InsertOutcome {
         let allowed = self
             .allowed_feeds
@@ -59,13 +68,49 @@ impl OracleStore {
             return InsertOutcome::Unexpected;
         }
         let key = FeedKey::new(provider_id, feed_id);
-        if let Some((_, existing_time)) = self.reports.get(&key) {
-            if *existing_time >= payload_time_ms {
+        let now = Instant::now();
+        if let Some(existing) = self.reports.get_mut(&key) {
+            if existing.source_time_ms > source_time_ms {
                 return InsertOutcome::Stale;
             }
+            let tied = existing.source_time_ms == source_time_ms;
+            if tied && existing.payload.as_ref() == payload.as_slice() {
+                existing.updated = now;
+                return InsertOutcome::Duplicate;
+            }
+            *existing = Report {
+                payload: Bytes::from(payload),
+                source_time_ms,
+                updated: now,
+            };
+            return if tied {
+                InsertOutcome::Conflict
+            } else {
+                InsertOutcome::Inserted
+            };
         }
-        self.reports.insert(key, (Bytes::from(payload), payload_time_ms));
+        self.reports.insert(
+            key,
+            Report {
+                payload: Bytes::from(payload),
+                source_time_ms,
+                updated: now,
+            },
+        );
         InsertOutcome::Inserted
+    }
+
+    fn evict_expired(&mut self, now: Instant, ttl: Duration) -> Vec<FeedKey> {
+        let expired: Vec<FeedKey> = self
+            .reports
+            .iter()
+            .filter(|(_, report)| now.duration_since(report.updated) >= ttl)
+            .map(|(key, _)| *key)
+            .collect();
+        for key in &expired {
+            self.reports.remove(key);
+        }
+        expired
     }
 
     fn register(
@@ -85,7 +130,7 @@ impl OracleStore {
         let evicted = self.retain_allowed_feeds();
         RegisterOutcome {
             evicted,
-            feeds_diverged: self.feeds_diverged(provider_id),
+            feed_set_conflicts: self.feed_set_conflicts(provider_id),
         }
     }
 
@@ -126,16 +171,22 @@ impl OracleStore {
         before - self.reports.len()
     }
 
-    fn feeds_diverged(&self, provider_id: B256) -> bool {
+    fn feed_set_conflicts(&self, provider_id: B256) -> Vec<B256> {
         let mut sets = self
             .source_feeds
             .values()
             .filter(|entry| entry.provider_id == provider_id)
             .map(|entry| &entry.feeds);
         let Some(first) = sets.next() else {
-            return false;
+            return Vec::new();
         };
-        sets.any(|set| set != first)
+        let mut union = first.clone();
+        let mut intersection = first.clone();
+        for set in sets {
+            union.extend(set.iter().copied());
+            intersection.retain(|feed| set.contains(feed));
+        }
+        union.difference(&intersection).copied().collect()
     }
 }
 
@@ -147,11 +198,11 @@ pub fn insert_if_newer(
     provider_id: B256,
     feed_id: B256,
     payload: Vec<u8>,
-    payload_time_ms: u64,
+    source_time_ms: u64,
 ) -> InsertOutcome {
     ORACLE_STORE
         .write()
-        .insert_if_newer(provider_id, feed_id, payload, payload_time_ms)
+        .insert_if_newer(provider_id, feed_id, payload, source_time_ms)
 }
 
 pub fn register_feeds(source_name: &str, provider_id: B256, feeds: Vec<B256>) -> RegisterOutcome {
@@ -162,6 +213,10 @@ pub fn register_feeds(source_name: &str, provider_id: B256, feeds: Vec<B256>) ->
 
 pub fn remove_source(source_name: &str) -> usize {
     ORACLE_STORE.write().remove_source(source_name)
+}
+
+pub fn evict_expired(ttl: Duration) -> Vec<FeedKey> {
+    ORACLE_STORE.write().evict_expired(Instant::now(), ttl)
 }
 
 #[cfg(test)]
@@ -200,10 +255,6 @@ mod tests {
             InsertOutcome::Stale
         );
         assert_eq!(
-            store.insert_if_newer(provider(0x01), feed(0xaa), vec![3], 100),
-            InsertOutcome::Stale
-        );
-        assert_eq!(
             store.insert_if_newer(provider(0x01), feed(0xaa), vec![4], 110),
             InsertOutcome::Inserted
         );
@@ -217,12 +268,67 @@ mod tests {
     }
 
     #[test]
+    fn equal_timestamp_conflict_overwrites() {
+        let mut store = OracleStore::default();
+        store.register("chainlink-1", provider(0x01), vec![feed(0xaa)]);
+        store.insert_if_newer(provider(0x01), feed(0xaa), vec![1], 100);
+        assert_eq!(
+            store.insert_if_newer(provider(0x01), feed(0xaa), vec![2], 100),
+            InsertOutcome::Conflict
+        );
+        let snapshot = store.snapshot();
+        assert_eq!(
+            snapshot
+                .get(&FeedKey::new(provider(0x01), feed(0xaa)))
+                .unwrap(),
+            &Bytes::from(vec![2])
+        );
+    }
+
+    #[test]
+    fn equal_timestamp_duplicate_is_skipped() {
+        let mut store = OracleStore::default();
+        store.register("chainlink-1", provider(0x01), vec![feed(0xaa)]);
+        store.insert_if_newer(provider(0x01), feed(0xaa), vec![1], 100);
+        assert_eq!(
+            store.insert_if_newer(provider(0x01), feed(0xaa), vec![1], 100),
+            InsertOutcome::Duplicate
+        );
+    }
+
+    #[test]
+    fn evicts_expired_reports() {
+        let mut store = OracleStore::default();
+        store.register("chainlink-1", provider(0x01), vec![feed(0xaa)]);
+        store.insert_if_newer(provider(0x01), feed(0xaa), vec![1], 100);
+        let now = Instant::now();
+        let ttl = Duration::from_secs(300);
+        assert!(store.evict_expired(now, ttl).is_empty());
+        let evicted = store.evict_expired(now + Duration::from_secs(600), ttl);
+        assert_eq!(evicted, vec![FeedKey::new(provider(0x01), feed(0xaa))]);
+        assert!(store.reports.is_empty());
+    }
+
+    #[test]
+    fn duplicate_refreshes_expiry() {
+        let mut store = OracleStore::default();
+        store.register("chainlink-1", provider(0x01), vec![feed(0xaa)]);
+        store.insert_if_newer(provider(0x01), feed(0xaa), vec![1], 100);
+        let key = FeedKey::new(provider(0x01), feed(0xaa));
+        store.reports.get_mut(&key).unwrap().updated -= Duration::from_secs(600);
+        store.insert_if_newer(provider(0x01), feed(0xaa), vec![1], 100);
+        assert!(store
+            .evict_expired(Instant::now(), Duration::from_secs(300))
+            .is_empty());
+    }
+
+    #[test]
     fn unions_replica_feeds() {
         let mut store = OracleStore::default();
         let out = store.register("chainlink-1", provider(0x01), vec![feed(0xaa), feed(0xbb)]);
-        assert!(!out.feeds_diverged);
+        assert!(out.feed_set_conflicts.is_empty());
         let out = store.register("chainlink-2", provider(0x01), vec![feed(0xaa)]);
-        assert!(out.feeds_diverged);
+        assert_eq!(out.feed_set_conflicts, vec![feed(0xbb)]);
         assert_eq!(
             store.insert_if_newer(provider(0x01), feed(0xbb), vec![1], 100),
             InsertOutcome::Inserted

--- a/crates/rollup/Cargo.toml
+++ b/crates/rollup/Cargo.toml
@@ -42,6 +42,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 borsh = { workspace = true }
 clap = { workspace = true, features = ["derive", "string"] }
+parking_lot = { workspace = true }
 serde = { workspace = true }
 tracing = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/rollup/src/oracle.rs
+++ b/crates/rollup/src/oracle.rs
@@ -65,38 +65,17 @@ pub struct OracleConfig {
     pub sources: Vec<SourceConfig>,
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum Transport {
-    #[default]
-    Tcp,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SourceConfig {
     pub name: String,
-    pub provider_id: String,
-    #[serde(default)]
-    pub transport: Transport,
-    #[serde(default)]
-    pub socket_address: Option<String>,
+    pub provider: String,
+    pub address: String,
 }
 
 impl SourceConfig {
     fn provider_hash(&self) -> B256 {
-        alloy_primitives::keccak256(self.provider_id.as_bytes())
-    }
-
-    fn address(&self) -> anyhow::Result<String> {
-        match self.transport {
-            Transport::Tcp => self.socket_address.clone().ok_or_else(|| {
-                anyhow!(
-                    "oracle source '{}': transport = \"tcp\" requires socket_address",
-                    self.name
-                )
-            }),
-        }
+        alloy_primitives::keccak256(self.provider.as_bytes())
     }
 }
 
@@ -118,7 +97,6 @@ fn validate(config: &OracleConfig) -> anyhow::Result<()> {
         if !seen.insert(source.name.as_str()) {
             return Err(anyhow!("duplicate oracle source name '{}'", source.name));
         }
-        source.address()?;
     }
     Ok(())
 }
@@ -191,9 +169,7 @@ pub async fn spawn_clients(config: OracleConfig, path: PathBuf) -> anyhow::Resul
     let mut registry: HashMap<String, SourceHandle> = HashMap::new();
     for source in config.sources {
         let name = source.name.clone();
-        if let Some(handle) = spawn_source(source, ready_tx.clone()) {
-            registry.insert(name, handle);
-        }
+        registry.insert(name, spawn_source(source, ready_tx.clone()));
     }
     drop(ready_tx);
 
@@ -256,22 +232,16 @@ async fn await_sources_ready(
 fn spawn_source(
     source: SourceConfig,
     ready: Option<mpsc::UnboundedSender<String>>,
-) -> Option<SourceHandle> {
-    let address = match source.address() {
-        Ok(address) => address,
-        Err(e) => {
-            error!(source = %source.name, error = %e, "Skipping oracle source with invalid address");
-            return None;
-        }
-    };
+) -> SourceHandle {
+    let address = source.address.clone();
     info!(source = %source.name, address = %address, "Starting oracle source client");
     let (cancel_tx, cancel_rx) = watch::channel(());
     let join = tokio::spawn(supervise_source(source.clone(), address, ready, cancel_rx));
-    Some(SourceHandle {
+    SourceHandle {
         config: source,
         cancel: cancel_tx,
         join,
-    })
+    }
 }
 
 async fn ignore_sighup() {
@@ -392,16 +362,12 @@ async fn apply_source_diff(
             info!(source = %name, "Restarting oracle source (config changed)");
             handle.shutdown().await;
         }
-        if let Some(handle) = spawn_source(source, None) {
-            registry.insert(name, handle);
-        }
+        registry.insert(name, spawn_source(source, None));
     }
     for source in diff.to_add {
         let name = source.name.clone();
         info!(source = %name, "Adding oracle source (config reload)");
-        if let Some(handle) = spawn_source(source, None) {
-            registry.insert(name, handle);
-        }
+        registry.insert(name, spawn_source(source, None));
     }
 
     debug!(added, restarted, removed, "Applied oracle config reload");
@@ -563,7 +529,7 @@ async fn consume(
                 if provider_id != source.provider_hash() {
                     warn!(
                         source = %source.name,
-                        expected = %source.provider_id,
+                        expected = %source.provider,
                         advertised = %provider_id,
                         "Oracle source advertised an unexpected provider id, dropping connection"
                     );
@@ -875,7 +841,7 @@ mod metrics {
 mod tests {
     use super::*;
 
-    const PROVIDER_ID: &str = "chainlink";
+    const PROVIDER: &str = "chainlink";
 
     #[test]
     fn require_sources_defaults_to_false() {
@@ -885,24 +851,9 @@ mod tests {
         assert!(!config.require_sources);
     }
 
-    #[test]
-    fn transport_defaults_to_tcp() {
-        let toml = format!(
-            r#"
-            [oracle]
-            [[oracle.source]]
-            name = "chainlink"
-            provider_id = "{PROVIDER_ID}"
-            socket_address = "127.0.0.1:9801"
-        "#
-        );
-        let config = toml::from_str::<OracleConfigFile>(&toml).unwrap().oracle;
-        assert_eq!(config.sources[0].transport, Transport::Tcp);
-    }
-
     fn source(toml: &str) -> SourceConfig {
         toml::from_str::<OracleConfigFile>(&format!(
-            "[oracle]\n[[oracle.source]]\nprovider_id = \"{PROVIDER_ID}\"\n{toml}"
+            "[oracle]\n[[oracle.source]]\nprovider = \"{PROVIDER}\"\n{toml}"
         ))
         .unwrap()
         .oracle
@@ -919,13 +870,12 @@ mod tests {
             require_sources = true
             [[oracle.source]]
             name = "chainlink-1"
-            provider_id = "{PROVIDER_ID}"
-            transport = "tcp"
-            socket_address = "127.0.0.1:9801"
+            provider = "{PROVIDER}"
+            address = "127.0.0.1:9801"
             [[oracle.source]]
             name = "chainlink-2"
-            provider_id = "{PROVIDER_ID}"
-            socket_address = "127.0.0.1:9802"
+            provider = "{PROVIDER}"
+            address = "127.0.0.1:9802"
         "#
         );
         let config = toml::from_str::<OracleConfigFile>(&toml).unwrap().oracle;
@@ -933,48 +883,36 @@ mod tests {
         assert!(config.require_sources);
         assert_eq!(config.sources.len(), 2);
         assert_eq!(config.sources[0].name, "chainlink-1");
-        assert_eq!(config.sources[0].provider_id, PROVIDER_ID);
+        assert_eq!(config.sources[0].provider, PROVIDER);
         assert_eq!(
             config.sources[0].provider_hash(),
-            alloy_primitives::keccak256(PROVIDER_ID)
+            alloy_primitives::keccak256(PROVIDER)
         );
-        assert_eq!(config.sources[0].transport, Transport::Tcp);
-        assert_eq!(config.sources[1].transport, Transport::Tcp);
+        assert_eq!(config.sources[1].address, "127.0.0.1:9802");
     }
 
     #[test]
-    fn missing_provider_id_is_an_error() {
+    fn missing_provider_is_an_error() {
         let toml = r#"
             [oracle]
             [[oracle.source]]
             name = "chainlink"
-            socket_address = "127.0.0.1:9801"
+            address = "127.0.0.1:9801"
         "#;
         assert!(toml::from_str::<OracleConfigFile>(toml).is_err());
     }
 
     #[test]
-    fn tcp_source_resolves_to_address() {
-        let s = source("name = \"a\"\ntransport = \"tcp\"\nsocket_address = \"127.0.0.1:9802\"");
-        assert_eq!(s.address().unwrap(), "127.0.0.1:9802");
+    fn source_parses_address() {
+        let s = source("name = \"a\"\naddress = \"127.0.0.1:9802\"");
+        assert_eq!(s.address, "127.0.0.1:9802");
     }
 
     #[test]
-    fn default_transport_resolves_to_address() {
-        let s = source("name = \"a\"\nsocket_address = \"127.0.0.1:9802\"");
-        assert_eq!(s.address().unwrap(), "127.0.0.1:9802");
-    }
-
-    #[test]
-    fn tcp_without_socket_address_is_an_error() {
-        let s = source("name = \"a\"\ntransport = \"tcp\"");
-        assert!(s.address().is_err());
-    }
-
-    #[test]
-    fn default_transport_without_address_is_an_error() {
-        let s = source("name = \"a\"");
-        assert!(s.address().is_err());
+    fn missing_address_is_an_error() {
+        let toml =
+            format!("[oracle]\n[[oracle.source]]\nname = \"a\"\nprovider = \"{PROVIDER}\"");
+        assert!(toml::from_str::<OracleConfigFile>(&toml).is_err());
     }
 
     #[test]
@@ -1029,19 +967,18 @@ mod tests {
         assert!(load_config(&path).is_err());
     }
 
-    fn tcp_src(name: &str, address: &str) -> SourceConfig {
+    fn src(name: &str, address: &str) -> SourceConfig {
         SourceConfig {
             name: name.to_string(),
-            provider_id: PROVIDER_ID.to_string(),
-            transport: Transport::Tcp,
-            socket_address: Some(address.to_string()),
+            provider: PROVIDER.to_string(),
+            address: address.to_string(),
         }
     }
 
     #[test]
     fn duplicate_source_names_are_rejected() {
         let config = OracleConfig {
-            sources: vec![tcp_src("dup", "127.0.0.1:1"), tcp_src("dup", "127.0.0.1:2")],
+            sources: vec![src("dup", "127.0.0.1:1"), src("dup", "127.0.0.1:2")],
             ..Default::default()
         };
         assert!(validate(&config).is_err());
@@ -1050,7 +987,7 @@ mod tests {
     #[test]
     fn unique_source_names_pass_validation() {
         let config = OracleConfig {
-            sources: vec![tcp_src("a", "127.0.0.1:1"), tcp_src("b", "127.0.0.1:2")],
+            sources: vec![src("a", "127.0.0.1:1"), src("b", "127.0.0.1:2")],
             ..Default::default()
         };
         assert!(validate(&config).is_ok());
@@ -1059,14 +996,14 @@ mod tests {
     #[test]
     fn diff_add_remove_restart() {
         let mut current = HashMap::new();
-        current.insert("keep".to_string(), tcp_src("keep", "127.0.0.1:1"));
-        current.insert("change".to_string(), tcp_src("change", "127.0.0.1:2"));
-        current.insert("drop".to_string(), tcp_src("drop", "127.0.0.1:3"));
+        current.insert("keep".to_string(), src("keep", "127.0.0.1:1"));
+        current.insert("change".to_string(), src("change", "127.0.0.1:2"));
+        current.insert("drop".to_string(), src("drop", "127.0.0.1:3"));
 
         let new_sources = vec![
-            tcp_src("keep", "127.0.0.1:1"),
-            tcp_src("change", "127.0.0.1:9"),
-            tcp_src("add", "127.0.0.1:4"),
+            src("keep", "127.0.0.1:1"),
+            src("change", "127.0.0.1:9"),
+            src("add", "127.0.0.1:4"),
         ];
         let diff = diff_sources(&current, new_sources);
 

--- a/crates/rollup/src/oracle.rs
+++ b/crates/rollup/src/oracle.rs
@@ -33,7 +33,7 @@ const PROVIDER_FEEDS_MAX: usize = 512;
 const HEARTBEAT_INTERVAL_MAX_SEC: u32 = 300;
 const THROTTLE_WARN_SEC: u64 = 60;
 
-static LAST_DROPPED_WARN_AT: AtomicU64 = AtomicU64::new(0);
+static LAST_UNADVERTISED_WARN_AT: AtomicU64 = AtomicU64::new(0);
 static LAST_DIVERGENCE_WARN_AT: AtomicU64 = AtomicU64::new(0);
 
 fn warn_allowed(last: &AtomicU64) -> bool {
@@ -592,12 +592,12 @@ async fn consume(
                 provider_id,
                 feed_id,
                 payload,
-                ingested_at,
-                source_time,
+                delivery_time_ms,
+                source_time_ms,
             } => {
                 if Some(provider_id) != session_provider {
-                    metrics::inc_dropped_unexpected(&source.name);
-                    if warn_allowed(&LAST_DROPPED_WARN_AT) {
+                    metrics::inc_unadvertised(&source.name);
+                    if warn_allowed(&LAST_UNADVERTISED_WARN_AT) {
                         warn!(
                             source = %source.name,
                             %provider_id,
@@ -606,22 +606,22 @@ async fn consume(
                     }
                     continue;
                 }
-                let age = now_unix().saturating_sub(ingested_at);
+                let age_ms = now_unix_ms().saturating_sub(delivery_time_ms);
                 trace!(
                     target: "oracle::frames",
                     source = %source.name,
                     %feed_id,
-                    age_secs = age,
+                    age_ms,
                     bytes = payload.len(),
                     "Received price update"
                 );
-                if age > STALENESS_WARN_SEC {
+                if age_ms > STALENESS_WARN_SEC * 1000 {
                     if !stale {
                         stale = true;
                         warn!(
                             source = %source.name,
                             %feed_id,
-                            age_secs = age,
+                            age_ms,
                             "Oracle source data is stale (payload older than threshold)"
                         );
                     }
@@ -629,16 +629,17 @@ async fn consume(
                     stale = false;
                     info!(source = %source.name, "Oracle source data freshness recovered");
                 }
-                let order_time = if source_time != 0 {
-                    source_time
+                let payload_time_ms = if source_time_ms != 0 {
+                    source_time_ms
                 } else {
-                    ingested_at
+                    delivery_time_ms
                 };
-                match prices::insert_if_newer(provider_id, feed_id, payload, order_time) {
-                    prices::InsertOutcome::Inserted | prices::InsertOutcome::Stale => {}
+                match prices::insert_if_newer(provider_id, feed_id, payload, payload_time_ms) {
+                    prices::InsertOutcome::Inserted => metrics::inc_inserted(&source.name),
+                    prices::InsertOutcome::Stale => metrics::inc_stale(&source.name),
                     prices::InsertOutcome::Unexpected => {
-                        metrics::inc_dropped_unexpected(&source.name);
-                        if warn_allowed(&LAST_DROPPED_WARN_AT) {
+                        metrics::inc_unadvertised(&source.name);
+                        if warn_allowed(&LAST_UNADVERTISED_WARN_AT) {
                             warn!(
                                 source = %source.name,
                                 %feed_id,
@@ -648,11 +649,11 @@ async fn consume(
                     }
                 }
             }
-            OracleFrame::Heartbeat { sent_at_unix } => {
+            OracleFrame::Heartbeat { send_time_ms } => {
                 trace!(
                     target: "oracle::frames",
                     source = %source.name,
-                    sent_at_unix,
+                    send_time_ms,
                     "Received heartbeat"
                 );
             }
@@ -665,6 +666,13 @@ fn now_unix() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
+}
+
+fn now_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
 }
 
 mod metrics {
@@ -683,7 +691,9 @@ mod metrics {
         reconnects: AtomicU64,
         frames: AtomicU64,
         last_frame_unix: AtomicU64,
-        dropped_unexpected: AtomicU64,
+        inserted: AtomicU64,
+        stale: AtomicU64,
+        unadvertised: AtomicU64,
         divergent_feeds: AtomicU64,
     }
 
@@ -717,10 +727,16 @@ mod metrics {
             .store(unix_secs, Ordering::Relaxed);
     }
 
-    pub fn inc_dropped_unexpected(name: &str) {
-        source(name)
-            .dropped_unexpected
-            .fetch_add(1, Ordering::Relaxed);
+    pub fn inc_inserted(name: &str) {
+        source(name).inserted.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_stale(name: &str) {
+        source(name).stale.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_unadvertised(name: &str) {
+        source(name).unadvertised.fetch_add(1, Ordering::Relaxed);
     }
 
     pub fn inc_divergent_feeds(name: &str) {
@@ -735,7 +751,9 @@ mod metrics {
         reconnects: u64,
         frames: u64,
         last_frame_unix: u64,
-        dropped_unexpected: u64,
+        inserted: u64,
+        stale: u64,
+        unadvertised: u64,
         divergent_feeds: u64,
     }
 
@@ -747,14 +765,16 @@ mod metrics {
         fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> io::Result<()> {
             write!(
                 buffer,
-                "{},source={} connected={},reconnects={},frames={},last_frame={},dropped_unexpected={},divergent_feeds={}",
+                "{},source={} connected={},reconnects={},frames={},last_frame={},inserted={},stale={},unadvertised={},divergent_feeds={}",
                 self.measurement_name(),
                 sov_metrics::safe_telegraf_string(&self.source),
                 self.connected as u8,
                 self.reconnects,
                 self.frames,
                 self.last_frame_unix,
-                self.dropped_unexpected,
+                self.inserted,
+                self.stale,
+                self.unadvertised,
                 self.divergent_feeds,
             )
         }
@@ -781,7 +801,9 @@ mod metrics {
                     reconnects: metrics.reconnects.load(Ordering::Relaxed),
                     frames: metrics.frames.load(Ordering::Relaxed),
                     last_frame_unix: metrics.last_frame_unix.load(Ordering::Relaxed),
-                    dropped_unexpected: metrics.dropped_unexpected.load(Ordering::Relaxed),
+                    inserted: metrics.inserted.load(Ordering::Relaxed),
+                    stale: metrics.stale.load(Ordering::Relaxed),
+                    unadvertised: metrics.unadvertised.load(Ordering::Relaxed),
                     divergent_feeds: metrics.divergent_feeds.load(Ordering::Relaxed),
                 })
                 .collect()
@@ -794,7 +816,9 @@ mod metrics {
                 reconnects = metric.reconnects,
                 frames = metric.frames,
                 last_frame = metric.last_frame_unix,
-                dropped_unexpected = metric.dropped_unexpected,
+                inserted = metric.inserted,
+                stale = metric.stale,
+                unadvertised = metric.unadvertised,
                 divergent_feeds = metric.divergent_feeds,
                 "oracle source metrics"
             );

--- a/crates/rollup/src/oracle.rs
+++ b/crates/rollup/src/oracle.rs
@@ -3,13 +3,12 @@ use std::fs;
 use std::future;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::{anyhow, Context};
 use price_oracle_ipc::{
     connect, read_frame_with_timeout, Backoff, IpcError, OracleFrame, OracleStream, B256,
-    PROTOCOL_VERSION,
+    FEEDS_MAX, PROTOCOL_VERSION, READ_DEADLINE,
 };
 use serde::Deserialize;
 use tokio::signal::unix::{signal, SignalKind};
@@ -21,28 +20,32 @@ use stf_starter::prices;
 
 const ORACLE_CONFIG_FILE: &str = "oracle.toml";
 const ORACLE_CONFIG_CONTENT: &str = "[oracle]\nenabled = false\n";
-const DEADLINE_HEARTBEAT_MULTIPLIER: u32 = 3;
-const BOOTSTRAP_DEADLINE: Duration = Duration::from_secs(30);
 const SUPERVISOR_GUARD_MIN: Duration = Duration::from_secs(1);
 const SUPERVISOR_GUARD_MAX: Duration = Duration::from_secs(30);
 const HEALTHY_CONNECTION_THRESHOLD: Duration = Duration::from_secs(10);
-const STALENESS_WARN_SEC: u64 = 30;
 const REQUIRE_SOURCES_TIMEOUT: Duration = Duration::from_secs(5);
 const METRICS_REPORT_INTERVAL: Duration = Duration::from_secs(15);
-const PROVIDER_FEEDS_MAX: usize = 512;
-const HEARTBEAT_INTERVAL_MAX_SEC: u32 = 300;
-const THROTTLE_WARN_SEC: u64 = 60;
+const WARN_THROTTLE: Duration = Duration::from_secs(60);
+const REPORT_TTL: Duration = Duration::from_secs(300);
+const TTL_SWEEP_INTERVAL: Duration = Duration::from_secs(30);
 
-static LAST_UNADVERTISED_WARN_AT: AtomicU64 = AtomicU64::new(0);
-static LAST_DIVERGENCE_WARN_AT: AtomicU64 = AtomicU64::new(0);
+#[derive(Default)]
+struct WarnThrottle {
+    last: Option<Instant>,
+}
 
-fn warn_allowed(last: &AtomicU64) -> bool {
-    let now = now_unix();
-    let prev = last.load(Ordering::Relaxed);
-    now.saturating_sub(prev) >= THROTTLE_WARN_SEC
-        && last
-            .compare_exchange(prev, now, Ordering::Relaxed, Ordering::Relaxed)
-            .is_ok()
+impl WarnThrottle {
+    fn allow(&mut self) -> bool {
+        let now = Instant::now();
+        if self
+            .last
+            .is_some_and(|prev| now.duration_since(prev) < WARN_THROTTLE)
+        {
+            return false;
+        }
+        self.last = Some(now);
+        true
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -73,6 +76,7 @@ pub enum Transport {
 #[serde(deny_unknown_fields)]
 pub struct SourceConfig {
     pub name: String,
+    pub provider_id: String,
     #[serde(default)]
     pub transport: Transport,
     #[serde(default)]
@@ -80,6 +84,10 @@ pub struct SourceConfig {
 }
 
 impl SourceConfig {
+    fn provider_hash(&self) -> B256 {
+        alloy_primitives::keccak256(self.provider_id.as_bytes())
+    }
+
     fn address(&self) -> anyhow::Result<String> {
         match self.transport {
             Transport::Tcp => self.socket_address.clone().ok_or_else(|| {
@@ -196,8 +204,26 @@ pub async fn spawn_clients(config: OracleConfig, path: PathBuf) -> anyhow::Resul
     }
 
     tokio::spawn(metrics::run_reporter(METRICS_REPORT_INTERVAL));
+    tokio::spawn(ttl_sweeper());
     tokio::spawn(reload_manager(path, startup_config, registry));
     Ok(())
+}
+
+async fn ttl_sweeper() {
+    let mut ticker = tokio::time::interval(TTL_SWEEP_INTERVAL);
+    ticker.tick().await;
+    loop {
+        ticker.tick().await;
+        let evicted = prices::evict_expired(REPORT_TTL);
+        if !evicted.is_empty() {
+            metrics::add_evicted(evicted.len() as u64);
+            warn!(
+                count = evicted.len(),
+                feeds = ?evicted,
+                "Evicted oracle reports with no accepted update within the TTL"
+            );
+        }
+    }
 }
 
 async fn await_sources_ready(
@@ -397,7 +423,7 @@ async fn supervise_source(
             _ = cancel.changed() => {
                 child.abort();
                 let _ = child.await;
-                metrics::set_connected(&source.name, false);
+                metrics::handle(&source.name).set_connected(false);
                 info!(source = %source.name, "Oracle source stopped (config reload)");
                 return;
             }
@@ -406,7 +432,7 @@ async fn supervise_source(
                     warn!(source = %source.name, "Oracle client task exited unexpectedly, restarting");
                 }
                 Err(join_error) => {
-                    metrics::set_connected(&source.name, false);
+                    metrics::handle(&source.name).set_connected(false);
                     error!(source = %source.name, error = %join_error, "Oracle client task panicked, restarting");
                 }
             },
@@ -427,15 +453,6 @@ async fn supervise_source(
     }
 }
 
-fn heartbeat_deadline(heartbeat_interval_sec: u32) -> Duration {
-    if heartbeat_interval_sec == 0 {
-        return BOOTSTRAP_DEADLINE;
-    }
-    Duration::from_secs(
-        u64::from(heartbeat_interval_sec) * u64::from(DEADLINE_HEARTBEAT_MULTIPLIER),
-    )
-}
-
 async fn run_source(
     source: SourceConfig,
     address: String,
@@ -443,11 +460,12 @@ async fn run_source(
 ) {
     let mut backoff = Backoff::default();
     let mut reconnect = false;
+    let source_metrics = metrics::handle(&source.name);
     loop {
         let stream = match connect(&address).await {
             Ok(stream) => {
                 if reconnect {
-                    metrics::inc_reconnects(&source.name);
+                    source_metrics.inc_reconnects();
                     info!(source = %source.name, "Connected to oracle source");
                 }
                 stream
@@ -466,10 +484,10 @@ async fn run_source(
         };
         reconnect = true;
 
-        metrics::set_connected(&source.name, true);
+        source_metrics.set_connected(true);
         let started = Instant::now();
-        let outcome = consume(&source, stream, &mut ready).await;
-        metrics::set_connected(&source.name, false);
+        let outcome = consume(&source, &source_metrics, stream, &mut ready).await;
+        source_metrics.set_connected(false);
 
         if outcome.hello && started.elapsed() >= HEALTHY_CONNECTION_THRESHOLD {
             backoff.reset();
@@ -494,27 +512,33 @@ struct SessionOutcome {
 
 async fn consume(
     source: &SourceConfig,
+    source_metrics: &metrics::SourceMetrics,
     mut stream: OracleStream,
     ready: &mut Option<mpsc::UnboundedSender<String>>,
 ) -> SessionOutcome {
-    let mut read_deadline = BOOTSTRAP_DEADLINE;
-    let mut stale = false;
-    let mut hello = false;
     let mut session_provider: Option<B256> = None;
+    let mut unadvertised_warn = WarnThrottle::default();
+    let mut divergence_warn = WarnThrottle::default();
+    let mut conflict_warn = WarnThrottle::default();
     loop {
-        let frame = match read_frame_with_timeout(&mut stream, read_deadline).await {
+        let frame = match read_frame_with_timeout(&mut stream, READ_DEADLINE).await {
             Ok(frame) => frame,
-            Err(error) => return SessionOutcome { hello, error },
+            Err(error) => {
+                return SessionOutcome {
+                    hello: session_provider.is_some(),
+                    error,
+                }
+            }
         };
-        metrics::inc_frames(&source.name);
-        metrics::set_last_frame(&source.name, now_unix());
-        if !hello && !matches!(frame, OracleFrame::Hello { .. }) {
+        source_metrics.inc_frames();
+        source_metrics.set_last_frame(now_unix());
+        if session_provider.is_none() && !matches!(frame, OracleFrame::Hello { .. }) {
             warn!(
                 source = %source.name,
                 "Oracle source sent a frame before Hello, dropping connection"
             );
             return SessionOutcome {
-                hello,
+                hello: false,
                 error: IpcError::Closed,
             };
         }
@@ -523,7 +547,6 @@ async fn consume(
                 protocol_version,
                 provider_id,
                 feeds,
-                heartbeat_interval_sec,
             } => {
                 if protocol_version != PROTOCOL_VERSION {
                     warn!(
@@ -533,55 +556,55 @@ async fn consume(
                         "Oracle source protocol version mismatch, dropping connection"
                     );
                     return SessionOutcome {
-                        hello,
+                        hello: session_provider.is_some(),
+                        error: IpcError::Closed,
+                    };
+                }
+                if provider_id != source.provider_hash() {
+                    warn!(
+                        source = %source.name,
+                        expected = %source.provider_id,
+                        advertised = %provider_id,
+                        "Oracle source advertised an unexpected provider id, dropping connection"
+                    );
+                    return SessionOutcome {
+                        hello: session_provider.is_some(),
                         error: IpcError::Closed,
                     };
                 }
                 let feed_count = feeds.len();
-                if feed_count > PROVIDER_FEEDS_MAX {
+                if feed_count > FEEDS_MAX {
                     warn!(
                         source = %source.name,
                         feed_count,
-                        max = PROVIDER_FEEDS_MAX,
+                        max = FEEDS_MAX,
                         "Oracle source advertised too many feeds, dropping connection"
                     );
                     return SessionOutcome {
-                        hello,
-                        error: IpcError::Closed,
-                    };
-                }
-                if heartbeat_interval_sec > HEARTBEAT_INTERVAL_MAX_SEC {
-                    warn!(
-                        source = %source.name,
-                        heartbeat_interval_sec,
-                        max = HEARTBEAT_INTERVAL_MAX_SEC,
-                        "Oracle source advertised an excessive heartbeat interval, dropping connection"
-                    );
-                    return SessionOutcome {
-                        hello,
+                        hello: session_provider.is_some(),
                         error: IpcError::Closed,
                     };
                 }
                 let registration = prices::register_feeds(&source.name, provider_id, feeds);
-                if registration.feeds_diverged {
-                    metrics::inc_divergent_feeds(&source.name);
-                    if warn_allowed(&LAST_DIVERGENCE_WARN_AT) {
+                let conflicts = &registration.feed_set_conflicts;
+                if !conflicts.is_empty() {
+                    source_metrics.inc_feed_set_conflicts();
+                    if divergence_warn.allow() {
                         warn!(
                             source = %source.name,
                             %provider_id,
-                            "Oracle provider replicas advertise divergent feed sets"
+                            conflicting = conflicts.len(),
+                            sample = ?&conflicts[..conflicts.len().min(5)],
+                            "Oracle provider replicas advertise conflicting feed sets"
                         );
                     }
                 }
-                hello = true;
                 session_provider = Some(provider_id);
-                read_deadline = heartbeat_deadline(heartbeat_interval_sec);
                 info!(
                     source = %source.name,
                     %provider_id,
                     feed_count,
                     evicted = registration.evicted,
-                    heartbeat_interval_sec,
                     "Oracle source handshake"
                 );
                 if let Some(ready) = ready.take() {
@@ -589,57 +612,39 @@ async fn consume(
                 }
             }
             OracleFrame::PriceUpdate {
-                provider_id,
                 feed_id,
                 payload,
-                delivery_time_ms,
                 source_time_ms,
             } => {
-                if Some(provider_id) != session_provider {
-                    metrics::inc_unadvertised(&source.name);
-                    if warn_allowed(&LAST_UNADVERTISED_WARN_AT) {
-                        warn!(
-                            source = %source.name,
-                            %provider_id,
-                            "Oracle source sent an update for an unadvertised provider, dropping"
-                        );
-                    }
+                let Some(provider_id) = session_provider else {
                     continue;
-                }
-                let age_ms = now_unix_ms().saturating_sub(delivery_time_ms);
+                };
                 trace!(
                     target: "oracle::frames",
                     source = %source.name,
                     %feed_id,
-                    age_ms,
+                    source_time_ms,
                     bytes = payload.len(),
                     "Received price update"
                 );
-                if age_ms > STALENESS_WARN_SEC * 1000 {
-                    if !stale {
-                        stale = true;
-                        warn!(
-                            source = %source.name,
-                            %feed_id,
-                            age_ms,
-                            "Oracle source data is stale (payload older than threshold)"
-                        );
+                match prices::insert_if_newer(provider_id, feed_id, payload, source_time_ms) {
+                    prices::InsertOutcome::Inserted => source_metrics.inc_inserted(),
+                    prices::InsertOutcome::Duplicate => source_metrics.inc_duplicates(),
+                    prices::InsertOutcome::Conflict => {
+                        source_metrics.inc_payload_conflicts();
+                        if conflict_warn.allow() {
+                            warn!(
+                                source = %source.name,
+                                %feed_id,
+                                source_time_ms,
+                                "Oracle replicas sent conflicting payloads for the same timestamp"
+                            );
+                        }
                     }
-                } else if stale {
-                    stale = false;
-                    info!(source = %source.name, "Oracle source data freshness recovered");
-                }
-                let payload_time_ms = if source_time_ms != 0 {
-                    source_time_ms
-                } else {
-                    delivery_time_ms
-                };
-                match prices::insert_if_newer(provider_id, feed_id, payload, payload_time_ms) {
-                    prices::InsertOutcome::Inserted => metrics::inc_inserted(&source.name),
-                    prices::InsertOutcome::Stale => metrics::inc_stale(&source.name),
+                    prices::InsertOutcome::Stale => source_metrics.inc_stale(),
                     prices::InsertOutcome::Unexpected => {
-                        metrics::inc_unadvertised(&source.name);
-                        if warn_allowed(&LAST_UNADVERTISED_WARN_AT) {
+                        source_metrics.inc_unadvertised();
+                        if unadvertised_warn.allow() {
                             warn!(
                                 source = %source.name,
                                 %feed_id,
@@ -649,11 +654,10 @@ async fn consume(
                     }
                 }
             }
-            OracleFrame::Heartbeat { send_time_ms } => {
+            OracleFrame::Heartbeat => {
                 trace!(
                     target: "oracle::frames",
                     source = %source.name,
-                    send_time_ms,
                     "Received heartbeat"
                 );
             }
@@ -668,79 +672,79 @@ fn now_unix() -> u64 {
         .as_secs()
 }
 
-fn now_unix_ms() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as u64
-}
-
 mod metrics {
     use std::collections::BTreeMap;
     use std::io::{self, Write};
     use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-    use std::sync::{Arc, LazyLock, Mutex, PoisonError};
+    use std::sync::{Arc, LazyLock};
     use std::time::Duration;
+
+    use parking_lot::Mutex;
 
     use sov_metrics::Metric;
     use tracing::info;
 
     #[derive(Default)]
-    struct SourceMetrics {
+    pub struct SourceMetrics {
         connected: AtomicBool,
         reconnects: AtomicU64,
         frames: AtomicU64,
         last_frame_unix: AtomicU64,
         inserted: AtomicU64,
+        duplicates: AtomicU64,
+        payload_conflicts: AtomicU64,
         stale: AtomicU64,
         unadvertised: AtomicU64,
-        divergent_feeds: AtomicU64,
+        feed_set_conflicts: AtomicU64,
+    }
+
+    impl SourceMetrics {
+        pub fn set_connected(&self, connected: bool) {
+            self.connected.store(connected, Ordering::Relaxed);
+        }
+
+        pub fn inc_reconnects(&self) {
+            self.reconnects.fetch_add(1, Ordering::Relaxed);
+        }
+
+        pub fn inc_frames(&self) {
+            self.frames.fetch_add(1, Ordering::Relaxed);
+        }
+
+        pub fn set_last_frame(&self, unix_secs: u64) {
+            self.last_frame_unix.store(unix_secs, Ordering::Relaxed);
+        }
+
+        pub fn inc_inserted(&self) {
+            self.inserted.fetch_add(1, Ordering::Relaxed);
+        }
+
+        pub fn inc_duplicates(&self) {
+            self.duplicates.fetch_add(1, Ordering::Relaxed);
+        }
+
+        pub fn inc_payload_conflicts(&self) {
+            self.payload_conflicts.fetch_add(1, Ordering::Relaxed);
+        }
+
+        pub fn inc_stale(&self) {
+            self.stale.fetch_add(1, Ordering::Relaxed);
+        }
+
+        pub fn inc_unadvertised(&self) {
+            self.unadvertised.fetch_add(1, Ordering::Relaxed);
+        }
+
+        pub fn inc_feed_set_conflicts(&self) {
+            self.feed_set_conflicts.fetch_add(1, Ordering::Relaxed);
+        }
     }
 
     static SOURCES: LazyLock<Mutex<BTreeMap<String, Arc<SourceMetrics>>>> =
         LazyLock::new(|| Mutex::new(BTreeMap::new()));
 
-    fn source(name: &str) -> Arc<SourceMetrics> {
-        SOURCES
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .entry(name.to_owned())
-            .or_default()
-            .clone()
-    }
-
-    pub fn set_connected(name: &str, connected: bool) {
-        source(name).connected.store(connected, Ordering::Relaxed);
-    }
-
-    pub fn inc_reconnects(name: &str) {
-        source(name).reconnects.fetch_add(1, Ordering::Relaxed);
-    }
-
-    pub fn inc_frames(name: &str) {
-        source(name).frames.fetch_add(1, Ordering::Relaxed);
-    }
-
-    pub fn set_last_frame(name: &str, unix_secs: u64) {
-        source(name)
-            .last_frame_unix
-            .store(unix_secs, Ordering::Relaxed);
-    }
-
-    pub fn inc_inserted(name: &str) {
-        source(name).inserted.fetch_add(1, Ordering::Relaxed);
-    }
-
-    pub fn inc_stale(name: &str) {
-        source(name).stale.fetch_add(1, Ordering::Relaxed);
-    }
-
-    pub fn inc_unadvertised(name: &str) {
-        source(name).unadvertised.fetch_add(1, Ordering::Relaxed);
-    }
-
-    pub fn inc_divergent_feeds(name: &str) {
-        source(name).divergent_feeds.fetch_add(1, Ordering::Relaxed);
+    pub fn handle(name: &str) -> Arc<SourceMetrics> {
+        SOURCES.lock().entry(name.to_owned()).or_default().clone()
     }
 
     // One InfluxDB measurement per source, tagged by source name.
@@ -752,9 +756,11 @@ mod metrics {
         frames: u64,
         last_frame_unix: u64,
         inserted: u64,
+        duplicates: u64,
+        payload_conflicts: u64,
         stale: u64,
         unadvertised: u64,
-        divergent_feeds: u64,
+        feed_set_conflicts: u64,
     }
 
     impl Metric for OracleMetric {
@@ -765,7 +771,7 @@ mod metrics {
         fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> io::Result<()> {
             write!(
                 buffer,
-                "{},source={} connected={},reconnects={},frames={},last_frame={},inserted={},stale={},unadvertised={},divergent_feeds={}",
+                "{},source={} connected={},reconnects={},frames={},last_frame={},inserted={},duplicates={},payload_conflicts={},stale={},unadvertised={},feed_set_conflicts={}",
                 self.measurement_name(),
                 sov_metrics::safe_telegraf_string(&self.source),
                 self.connected as u8,
@@ -773,9 +779,37 @@ mod metrics {
                 self.frames,
                 self.last_frame_unix,
                 self.inserted,
+                self.duplicates,
+                self.payload_conflicts,
                 self.stale,
                 self.unadvertised,
-                self.divergent_feeds,
+                self.feed_set_conflicts,
+            )
+        }
+    }
+
+    static EVICTED: AtomicU64 = AtomicU64::new(0);
+
+    pub fn add_evicted(count: u64) {
+        EVICTED.fetch_add(count, Ordering::Relaxed);
+    }
+
+    #[derive(Debug)]
+    struct StoreMetric {
+        evicted: u64,
+    }
+
+    impl Metric for StoreMetric {
+        fn measurement_name(&self) -> &'static str {
+            "oracle_store"
+        }
+
+        fn serialize_for_telegraf(&self, buffer: &mut Vec<u8>) -> io::Result<()> {
+            write!(
+                buffer,
+                "{} evicted={}",
+                self.measurement_name(),
+                self.evicted,
             )
         }
     }
@@ -792,7 +826,7 @@ mod metrics {
 
     fn report_once() {
         let snapshot: Vec<OracleMetric> = {
-            let sources = SOURCES.lock().unwrap_or_else(PoisonError::into_inner);
+            let sources = SOURCES.lock();
             sources
                 .iter()
                 .map(|(name, metrics)| OracleMetric {
@@ -802,9 +836,11 @@ mod metrics {
                     frames: metrics.frames.load(Ordering::Relaxed),
                     last_frame_unix: metrics.last_frame_unix.load(Ordering::Relaxed),
                     inserted: metrics.inserted.load(Ordering::Relaxed),
+                    duplicates: metrics.duplicates.load(Ordering::Relaxed),
+                    payload_conflicts: metrics.payload_conflicts.load(Ordering::Relaxed),
                     stale: metrics.stale.load(Ordering::Relaxed),
                     unadvertised: metrics.unadvertised.load(Ordering::Relaxed),
-                    divergent_feeds: metrics.divergent_feeds.load(Ordering::Relaxed),
+                    feed_set_conflicts: metrics.feed_set_conflicts.load(Ordering::Relaxed),
                 })
                 .collect()
         };
@@ -817,19 +853,29 @@ mod metrics {
                 frames = metric.frames,
                 last_frame = metric.last_frame_unix,
                 inserted = metric.inserted,
+                duplicates = metric.duplicates,
+                payload_conflicts = metric.payload_conflicts,
                 stale = metric.stale,
                 unadvertised = metric.unadvertised,
-                divergent_feeds = metric.divergent_feeds,
+                feed_set_conflicts = metric.feed_set_conflicts,
                 "oracle source metrics"
             );
             sov_metrics::track_metrics(|tracker| tracker.submit(metric));
         }
+
+        let store = StoreMetric {
+            evicted: EVICTED.load(Ordering::Relaxed),
+        };
+        info!(evicted = store.evicted, "oracle store metrics");
+        sov_metrics::track_metrics(|tracker| tracker.submit(store));
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const PROVIDER_ID: &str = "chainlink";
 
     #[test]
     fn require_sources_defaults_to_false() {
@@ -841,45 +887,70 @@ mod tests {
 
     #[test]
     fn transport_defaults_to_tcp() {
+        let toml = format!(
+            r#"
+            [oracle]
+            [[oracle.source]]
+            name = "chainlink"
+            provider_id = "{PROVIDER_ID}"
+            socket_address = "127.0.0.1:9801"
+        "#
+        );
+        let config = toml::from_str::<OracleConfigFile>(&toml).unwrap().oracle;
+        assert_eq!(config.sources[0].transport, Transport::Tcp);
+    }
+
+    fn source(toml: &str) -> SourceConfig {
+        toml::from_str::<OracleConfigFile>(&format!(
+            "[oracle]\n[[oracle.source]]\nprovider_id = \"{PROVIDER_ID}\"\n{toml}"
+        ))
+        .unwrap()
+        .oracle
+        .sources
+        .remove(0)
+    }
+
+    #[test]
+    fn parses_full_config() {
+        let toml = format!(
+            r#"
+            [oracle]
+            enabled = true
+            require_sources = true
+            [[oracle.source]]
+            name = "chainlink-1"
+            provider_id = "{PROVIDER_ID}"
+            transport = "tcp"
+            socket_address = "127.0.0.1:9801"
+            [[oracle.source]]
+            name = "chainlink-2"
+            provider_id = "{PROVIDER_ID}"
+            socket_address = "127.0.0.1:9802"
+        "#
+        );
+        let config = toml::from_str::<OracleConfigFile>(&toml).unwrap().oracle;
+        assert!(config.enabled);
+        assert!(config.require_sources);
+        assert_eq!(config.sources.len(), 2);
+        assert_eq!(config.sources[0].name, "chainlink-1");
+        assert_eq!(config.sources[0].provider_id, PROVIDER_ID);
+        assert_eq!(
+            config.sources[0].provider_hash(),
+            alloy_primitives::keccak256(PROVIDER_ID)
+        );
+        assert_eq!(config.sources[0].transport, Transport::Tcp);
+        assert_eq!(config.sources[1].transport, Transport::Tcp);
+    }
+
+    #[test]
+    fn missing_provider_id_is_an_error() {
         let toml = r#"
             [oracle]
             [[oracle.source]]
             name = "chainlink"
             socket_address = "127.0.0.1:9801"
         "#;
-        let config = toml::from_str::<OracleConfigFile>(toml).unwrap().oracle;
-        assert_eq!(config.sources[0].transport, Transport::Tcp);
-    }
-
-    fn source(toml: &str) -> SourceConfig {
-        toml::from_str::<OracleConfigFile>(&format!("[oracle]\n[[oracle.source]]\n{toml}"))
-            .unwrap()
-            .oracle
-            .sources
-            .remove(0)
-    }
-
-    #[test]
-    fn parses_full_config() {
-        let toml = r#"
-            [oracle]
-            enabled = true
-            require_sources = true
-            [[oracle.source]]
-            name = "chainlink-1"
-            transport = "tcp"
-            socket_address = "127.0.0.1:9801"
-            [[oracle.source]]
-            name = "chainlink-2"
-            socket_address = "127.0.0.1:9802"
-        "#;
-        let config = toml::from_str::<OracleConfigFile>(toml).unwrap().oracle;
-        assert!(config.enabled);
-        assert!(config.require_sources);
-        assert_eq!(config.sources.len(), 2);
-        assert_eq!(config.sources[0].name, "chainlink-1");
-        assert_eq!(config.sources[0].transport, Transport::Tcp);
-        assert_eq!(config.sources[1].transport, Transport::Tcp);
+        assert!(toml::from_str::<OracleConfigFile>(toml).is_err());
     }
 
     #[test]
@@ -961,6 +1032,7 @@ mod tests {
     fn tcp_src(name: &str, address: &str) -> SourceConfig {
         SourceConfig {
             name: name.to_string(),
+            provider_id: PROVIDER_ID.to_string(),
             transport: Transport::Tcp,
             socket_address: Some(address.to_string()),
         }
@@ -1013,19 +1085,6 @@ mod tests {
             ["change"]
         );
         assert_eq!(diff.to_remove, ["drop"]);
-    }
-
-    #[test]
-    fn heartbeat_deadline_scales() {
-        assert_eq!(
-            heartbeat_deadline(10),
-            Duration::from_secs(10 * u64::from(DEADLINE_HEARTBEAT_MULTIPLIER))
-        );
-    }
-
-    #[test]
-    fn heartbeat_deadline_zero_interval() {
-        assert_eq!(heartbeat_deadline(0), BOOTSTRAP_DEADLINE);
     }
 
     #[tokio::test]

--- a/crates/shared/price-oracle-ipc/README.md
+++ b/crates/shared/price-oracle-ipc/README.md
@@ -43,7 +43,7 @@ Helpers wrap a local TCP connection (no TLS).
 - `OracleStream` - A connected TCP stream, implementing `AsyncRead` and `AsyncWrite`.
 - `OracleListener` - A bound listener, with `accept` and `local_addr`. Accepted connections get `TCP_NODELAY` and `SO_KEEPALIVE`.
 - `BoundListener` - Owns a bound listener and its resolved address, exposing it through `address()` (resolving an ephemeral `:0` port).
-- `Backoff` - A reusable exponential backoff helper, doubling from a minimum up to a maximum, defaulting to 1s through 30s.
+- `Backoff` - A reusable exponential backoff helper, doubling from a minimum up to a maximum, defaulting to 1s through 15s.
 
 ## Errors
 

--- a/crates/shared/price-oracle-ipc/README.md
+++ b/crates/shared/price-oracle-ipc/README.md
@@ -11,11 +11,15 @@ payload is carried as an opaque byte blob and this library does not decode or va
 Messages are `OracleFrame` values, serialized with Borsh.
 There are three variants.
 
-- `Hello` - Sent first by the server, carries the protocol version, provider id, the list of subscribed feeds, and the server's heartbeat interval in seconds.
-- `PriceUpdate` - A price report for one feed, with provider id, feed id, opaque payload, an ingested-at timestamp, and a source timestamp taken from the upstream report.
-- `Heartbeat` - A liveness ping carrying a Unix timestamp in seconds.
+- `Hello` - Sent first by the server, carries the protocol version, provider id, and the list of subscribed feeds.
+- `PriceUpdate` - A price report for one feed, with feed id, opaque payload, and a source timestamp in Unix milliseconds taken from the upstream report.
+- `Heartbeat` - A periodic liveness message.
 
 A feed is identified by a `FeedKey`, the pair of provider id and feed id, both 32-byte values.
+
+The heartbeat cadence is fixed by the protocol. A server must send some frame at
+least every `HEARTBEAT_INTERVAL` (5s), and a subscriber should treat a stream
+with no frame for `READ_DEADLINE` (15s) as dead.
 
 Each frame is length-prefixed.
 The wire layout is a 4-byte little-endian length followed by the Borsh-encoded frame body.
@@ -25,7 +29,7 @@ The wire layout is a 4-byte little-endian length followed by the Borsh-encoded f
 - `write_frame_with_timeout` - `write_frame` bounded by a deadline, returning `IpcError::WriteTimeout` on expiry.
 - `read_frame_with_timeout` - `read_frame` bounded by a deadline, returning `IpcError::ReadTimeout` on expiry.
 
-Frames larger than `MAX_FRAME_LEN` (16 MiB) are rejected on both read and write.
+Frames larger than `MAX_FRAME_LEN` (256 KiB) are rejected on both read and write.
 A clean end of stream while reading the length prefix is reported as `IpcError::Closed`
 rather than an I/O error. The codec works over any `AsyncRead` or `AsyncWrite`
 the socket type is not assumed.

--- a/crates/shared/price-oracle-ipc/src/codec.rs
+++ b/crates/shared/price-oracle-ipc/src/codec.rs
@@ -75,8 +75,8 @@ mod tests {
             provider_id: B256::repeat_byte(0xab),
             feed_id: B256::repeat_byte(0xcd),
             payload: vec![0x12, 0x34, 0x56, 0x78],
-            ingested_at: 0x1234_5678,
-            source_time: 0x1234_5670,
+            delivery_time_ms: 0x1234_5678,
+            source_time_ms: 0x1234_5670,
         }
     }
 

--- a/crates/shared/price-oracle-ipc/src/codec.rs
+++ b/crates/shared/price-oracle-ipc/src/codec.rs
@@ -5,7 +5,7 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use crate::error::IpcError;
 use crate::types::OracleFrame;
 
-pub const MAX_FRAME_LEN: u32 = 16 * 1024 * 1024;
+pub const MAX_FRAME_LEN: u32 = 256 * 1024;
 
 pub async fn write_frame<W>(writer: &mut W, frame: &OracleFrame) -> Result<(), IpcError>
 where
@@ -72,10 +72,8 @@ mod tests {
 
     fn sample_update() -> OracleFrame {
         OracleFrame::PriceUpdate {
-            provider_id: B256::repeat_byte(0xab),
             feed_id: B256::repeat_byte(0xcd),
             payload: vec![0x12, 0x34, 0x56, 0x78],
-            delivery_time_ms: 0x1234_5678,
             source_time_ms: 0x1234_5670,
         }
     }
@@ -96,7 +94,6 @@ mod tests {
             protocol_version: crate::PROTOCOL_VERSION,
             provider_id: B256::repeat_byte(0x01),
             feeds: vec![B256::repeat_byte(0x02), B256::repeat_byte(0x03)],
-            heartbeat_interval_sec: 10,
         };
         write_frame(&mut a, &hello).await.unwrap();
         write_frame(&mut a, &sample_update()).await.unwrap();

--- a/crates/shared/price-oracle-ipc/src/lib.rs
+++ b/crates/shared/price-oracle-ipc/src/lib.rs
@@ -10,6 +10,8 @@ pub use error::IpcError;
 pub use transport::{
     bind, connect, Backoff, BoundListener, OracleListener, OracleStream, DEFAULT_CONNECT_TIMEOUT,
 };
-pub use types::{FeedKey, OracleFrame, PROTOCOL_VERSION};
+pub use types::{
+    FeedKey, OracleFrame, FEEDS_MAX, HEARTBEAT_INTERVAL, PROTOCOL_VERSION, READ_DEADLINE,
+};
 
 pub use alloy_primitives::B256;

--- a/crates/shared/price-oracle-ipc/src/transport.rs
+++ b/crates/shared/price-oracle-ipc/src/transport.rs
@@ -8,7 +8,7 @@ use tokio::net::{TcpListener, TcpStream};
 use crate::error::IpcError;
 
 pub const DEFAULT_BACKOFF_MIN: Duration = Duration::from_secs(1);
-pub const DEFAULT_BACKOFF_MAX: Duration = Duration::from_secs(30);
+pub const DEFAULT_BACKOFF_MAX: Duration = Duration::from_secs(15);
 pub const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 pub const DEFAULT_KEEPALIVE_IDLE: Duration = Duration::from_secs(15);
 pub const DEFAULT_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(5);

--- a/crates/shared/price-oracle-ipc/src/types.rs
+++ b/crates/shared/price-oracle-ipc/src/types.rs
@@ -1,7 +1,12 @@
+use std::time::Duration;
+
 use alloy_primitives::B256;
 use borsh::{BorshDeserialize, BorshSerialize};
 
 pub const PROTOCOL_VERSION: u16 = 2;
+pub const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
+pub const READ_DEADLINE: Duration = Duration::from_secs(15);
+pub const FEEDS_MAX: usize = 512;
 
 #[derive(
     Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, BorshSerialize, BorshDeserialize,
@@ -26,16 +31,11 @@ pub enum OracleFrame {
         protocol_version: u16,
         provider_id: B256,
         feeds: Vec<B256>,
-        heartbeat_interval_sec: u32,
     },
     PriceUpdate {
-        provider_id: B256,
         feed_id: B256,
         payload: Vec<u8>,
-        delivery_time_ms: u64,
         source_time_ms: u64,
     },
-    Heartbeat {
-        send_time_ms: u64,
-    },
+    Heartbeat,
 }

--- a/crates/shared/price-oracle-ipc/src/types.rs
+++ b/crates/shared/price-oracle-ipc/src/types.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::B256;
 use borsh::{BorshDeserialize, BorshSerialize};
 
-pub const PROTOCOL_VERSION: u16 = 1;
+pub const PROTOCOL_VERSION: u16 = 2;
 
 #[derive(
     Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, BorshSerialize, BorshDeserialize,
@@ -32,10 +32,10 @@ pub enum OracleFrame {
         provider_id: B256,
         feed_id: B256,
         payload: Vec<u8>,
-        ingested_at: u64,
-        source_time: u64,
+        delivery_time_ms: u64,
+        source_time_ms: u64,
     },
     Heartbeat {
-        sent_at_unix: u64,
+        send_time_ms: u64,
     },
 }

--- a/crates/shared/price-oracle-ipc/tests/common/mod.rs
+++ b/crates/shared/price-oracle-ipc/tests/common/mod.rs
@@ -23,13 +23,13 @@ pub fn update(feed: u8, payload: &[u8]) -> OracleFrame {
         provider_id: B256::repeat_byte(0x11),
         feed_id: B256::repeat_byte(feed),
         payload: payload.to_vec(),
-        ingested_at: 1_700_000_000,
-        source_time: 1_700_000_000,
+        delivery_time_ms: 1_700_000_000_000,
+        source_time_ms: 1_700_000_000_000,
     }
 }
 
-pub fn heartbeat(sent_at_unix: u64) -> OracleFrame {
-    OracleFrame::Heartbeat { sent_at_unix }
+pub fn heartbeat(send_time_ms: u64) -> OracleFrame {
+    OracleFrame::Heartbeat { send_time_ms }
 }
 
 pub fn serve_once(

--- a/crates/shared/price-oracle-ipc/tests/common/mod.rs
+++ b/crates/shared/price-oracle-ipc/tests/common/mod.rs
@@ -14,22 +14,19 @@ pub fn hello() -> OracleFrame {
         protocol_version: PROTOCOL_VERSION,
         provider_id: B256::repeat_byte(0x11),
         feeds: vec![B256::repeat_byte(0x01)],
-        heartbeat_interval_sec: 1,
     }
 }
 
 pub fn update(feed: u8, payload: &[u8]) -> OracleFrame {
     OracleFrame::PriceUpdate {
-        provider_id: B256::repeat_byte(0x11),
         feed_id: B256::repeat_byte(feed),
         payload: payload.to_vec(),
-        delivery_time_ms: 1_700_000_000_000,
         source_time_ms: 1_700_000_000_000,
     }
 }
 
-pub fn heartbeat(send_time_ms: u64) -> OracleFrame {
-    OracleFrame::Heartbeat { send_time_ms }
+pub fn heartbeat() -> OracleFrame {
+    OracleFrame::Heartbeat
 }
 
 pub fn serve_once(

--- a/crates/shared/price-oracle-ipc/tests/integration.rs
+++ b/crates/shared/price-oracle-ipc/tests/integration.rs
@@ -15,7 +15,7 @@ async fn session_round_trip() {
         common::hello(),
         common::update(0x01, b"snap-1"),
         common::update(0x02, b"snap-2"),
-        common::heartbeat(7),
+        common::heartbeat(),
         common::update(0x01, b"live-1"),
     ];
     let server = common::serve_once(listener, expected.clone());
@@ -81,7 +81,7 @@ async fn write_trips_deadline_when_peer_never_reads() {
     let address = listener.address().to_string();
     let server = tokio::spawn(async move {
         let mut stream = listener.accept().await.unwrap();
-        let big = common::update(0x01, &vec![0u8; 1024 * 1024]);
+        let big = common::update(0x01, &vec![0u8; 200 * 1024]);
         for _ in 0..1000 {
             match write_frame_with_timeout(&mut stream, &big, Duration::from_millis(100)).await {
                 Ok(()) => continue,


### PR DESCRIPTION
- Added support for millisecond timestamps
- Added TTL for feeds that are registered but have not been updated for some time
- Simplified the config file
- Bumped the protocol version to V2
- Cleaned up oracle metrics
- Removed transport options (TCP always)
- Default to Stork provider instead of Chainlink

**Note:** This will require sequencer restart